### PR TITLE
Add product spec and epic docs

### DIFF
--- a/EPIC_01_QUESTION_BANK_AND_ASSESSMENT_RULES.md
+++ b/EPIC_01_QUESTION_BANK_AND_ASSESSMENT_RULES.md
@@ -1,0 +1,222 @@
+# Epic 01: Question Bank and Assessment Rules
+
+This document defines the product and domain outcomes for the question system that powers Swipe Check. It is derived from `PRODUCT_SPEC.md` in the project root.
+
+This epic intentionally describes outcomes and constraints, not a prescribed implementation. A developer should be able to complete this work using the repository's existing conventions while still meeting the product goals.
+
+## Project Context
+
+Swipe Check is a daily `MBTI-style` personality journal.
+
+The app experience is built around two assessment modes:
+
+- A one-time onboarding assessment made up of `12` binary questions
+- A recurring daily check-in made up of `3` binary questions per day
+
+All questions use only two possible responses:
+
+- `Agree`
+- `Disagree`
+
+The app is not intended to reproduce the official MBTI instrument. It should be treated as `MBTI-style` and should avoid official proprietary question wording.
+
+## Epic Goal
+
+Create the complete assessment ruleset for the app so that every other epic has a clear, reliable foundation for:
+
+- what questions exist
+- how questions are categorized
+- how onboarding differs from daily questions
+- how daily questions are selected over time
+- how answers contribute to a user's current type and axis strength
+
+At the end of this epic, another developer should be able to build onboarding, daily sessions, Journal, and Insights without needing to invent or reinterpret the underlying personality logic.
+
+## Why This Epic Matters
+
+This is the domain core of the product. If the question system is vague or inconsistent, the rest of the app will produce contradictory behavior, unstable insights, and poor user trust.
+
+This epic is responsible for turning the product concept into a usable assessment model that is:
+
+- simple enough for daily use
+- balanced enough to feel intentional rather than random
+- deterministic enough to support reliable scoring and history
+- flexible enough for the UI and persistence layers to consume
+
+## In Scope
+
+- Define the canonical question structure for all assessments
+- Define the `12` onboarding questions and their intended axis coverage
+- Define the reusable daily question pool and its coverage expectations
+- Define how each question maps to one MBTI axis pair
+- Define which side of an axis is supported by `Agree`
+- Define expectations for direct and reverse-coded prompts
+- Define the daily question selection rules
+- Define the scoring rules used to compute the user's `Current Type`
+- Define the axis strength or confidence outputs needed by Insights
+- Define how completed sessions should produce type snapshots that can be stored or reconstructed later
+
+## Out of Scope
+
+- Screen implementation
+- Navigation or route structure
+- Local storage implementation
+- Charts and visualization
+- Settings behavior
+- Reminders, sync, or auth
+
+## Required Outcomes
+
+### 1. Canonical Question Contract
+
+Every active question in the system must have enough information to answer all of the following without ambiguity:
+
+- What is the prompt text?
+- Which axis pair does it belong to?
+- Which pole does `Agree` support?
+- Is it part of onboarding or the daily pool?
+- Is it currently active and available for selection?
+
+The system must make it possible for a downstream developer to reason about a question without relying on hidden assumptions.
+
+### 2. Onboarding Assessment Definition
+
+The onboarding assessment must be fixed, not dynamically generated.
+
+It must include exactly:
+
+- `12` questions total
+- `3` questions for each axis pair: `E/I`, `S/N`, `T/F`, `J/P`
+
+The onboarding set should give the user a credible initial result while staying lightweight and finishable.
+
+### 3. Daily Question Pool Definition
+
+The daily pool must be fully distinct from the onboarding set.
+
+Onboarding questions must never be selected for daily sessions.
+
+The daily pool must be large and balanced enough that:
+
+- the user does not see obvious repetition too quickly
+- all four axis pairs receive recurring exposure over time
+- the daily selection logic has enough options to avoid repeating yesterday's question when alternatives exist
+
+The exact daily pool size is not mandated by this epic, but the final set must support balanced recurring use rather than feeling exhausted after a few days.
+
+### 4. Daily Selection Rules
+
+Daily questions must not be chosen as pure random draws from the full bank.
+
+The daily selection rules are:
+
+- exactly `3` daily questions are shown on a given day
+- each day includes one question from each of the `3` axis pairs with the lowest cumulative daily exposure across completed daily sessions to date
+- if multiple axis pairs are tied on exposure, the tied axis that was least recently shown is selected first
+- if axis pairs are still tied after recent-use comparison, use fixed axis order: `E/I`, `S/N`, `T/F`, `J/P`
+- within each selected axis pair, choose the least-recently-used active daily question
+- avoid repeating yesterday's question when another valid question exists for that axis pair
+- when multiple valid questions remain for an axis pair, prefer the coding direction that has been used less often for that axis pair over time
+
+The output of this logic must be stable enough that another developer can implement it and verify that it matches the spec.
+
+### 5. Scoring Rules
+
+The system must clearly define how a binary answer changes personality scores.
+
+At minimum, the rules must support:
+
+- incrementing one side of one axis per answer
+- computing a user's `Current Type` from all answers to date
+- computing axis strength using the gap between the two poles on each axis
+- generating a type snapshot after a completed session
+
+The same answer history must always produce the same scoring result.
+
+### 6. Tie and Low-Data Behavior
+
+This epic must account for edge cases where:
+
+- one or more axes are tied
+- there is very little data available
+- the user has completed onboarding but very few daily sessions
+
+The tie behavior is:
+
+- the fixed `3` onboarding questions per axis pair create the user's initial non-tied baseline
+- if an axis pair later becomes tied, that axis pair retains its previously established letter rather than flipping or becoming unknown
+- all screens that present type information must use this same tie rule
+
+Low-data behavior must remain truthful and consistent across screens without inventing extra personality certainty beyond the available answer history.
+
+## Product Constraints
+
+- The app is `MBTI-style`, not the official MBTI assessment
+- No five-point scale exists in MVP
+- All answers are binary only
+- Onboarding is fixed and one-time per install unless local data is cleared
+- Daily questions must come from a pool fully separate from onboarding questions
+- Daily questions must be balanced over time rather than purely random
+- The `Current Type` is based on all answers to date, not just today's answers
+
+## Quality Expectations
+
+The question system should feel intentional and credible to the user.
+
+That means:
+
+- prompts should be easy to answer quickly
+- prompts should not feel duplicated or trivially reworded
+- the polarity of each prompt should be unambiguous
+- reverse-coded prompts should reduce obvious response bias
+- the scoring model should avoid surprising or contradictory outcomes
+
+## Cross-Epic Dependencies
+
+This epic can be completed before any screen or storage work exists.
+
+Other epics depend on this epic for:
+
+- the list of onboarding questions
+- the daily question pool
+- the question metadata contract
+- the daily question selection policy
+- the scoring and snapshot rules
+
+## Isolation Guidance
+
+This epic should be executable in isolation because it is primarily a domain-definition task.
+
+A developer working on this epic does not need to wait for:
+
+- final navigation
+- final UI components
+- final SQLite schema
+- final charts
+
+What matters is that the outputs of this epic are explicit enough for other developers to consume without reinterpretation.
+
+## Acceptance Criteria
+
+1. A developer unfamiliar with the project can identify the full onboarding question set and confirm that it contains exactly `12` questions with `3` questions per axis pair.
+2. Every active question in the system unambiguously identifies its axis pair and which pole is supported by `Agree`.
+3. The daily question pool is fully distinct from onboarding and documented well enough that another developer can implement balanced recurring selection without inventing additional product rules.
+4. The daily selection rules guarantee exactly `3` questions per day by choosing one question from each of the `3` least-exposed axis pairs, with deterministic tie-breakers.
+5. The scoring rules deterministically produce the same `Current Type` for the same history of answers.
+6. The system defines outputs that are sufficient for Journal and Insights to show a per-day type snapshot and a current overall type.
+7. Tie behavior and low-data behavior are documented well enough that different screens cannot present contradictory results, including retaining the previous axis value when a later tie occurs.
+8. The resulting question system does not rely on a five-point scale, cloud state, or official MBTI proprietary wording.
+
+## Validation Notes
+
+The person completing this epic should be able to demonstrate at least the following:
+
+- a clear list of onboarding questions and their metadata
+- a clear description of the daily pool and its coverage
+- example answer histories and the resulting type outputs
+- example daily selection scenarios showing balanced behavior across recent days
+- example tied-axis histories showing that the prior axis value is retained
+
+## Definition of Done
+
+This epic is done when the product's assessment model is explicit enough that other developers can build the app's flows and data features without making new domain decisions on their own.

--- a/EPIC_02_LOCAL_DATA_PLATFORM.md
+++ b/EPIC_02_LOCAL_DATA_PLATFORM.md
@@ -1,0 +1,214 @@
+# Epic 02: Local Data Platform
+
+This document defines the persistent data foundation for Swipe Check. It is derived from `PRODUCT_SPEC.md` in the project root.
+
+This epic intentionally focuses on outcomes, data responsibilities, and product constraints rather than prescribing a specific repository layout, migration style, or query implementation.
+
+## Project Context
+
+Swipe Check is a local-first mobile app in MVP.
+
+The product requires durable storage for:
+
+- question definitions
+- onboarding progress
+- daily sessions
+- individual answers
+- type snapshots over time
+- lightweight app preferences
+
+The MVP explicitly excludes auth, cloud sync, and backend dependency. The chosen storage direction for MVP is `SQLite`.
+
+## Epic Goal
+
+Create a persistent local data layer that makes the rest of the product possible.
+
+At the end of this epic, the app must be able to treat local data as the source of truth for:
+
+- whether onboarding is complete
+- what today's session is
+- whether a session is unfinished or completed
+- what the user's answer history contains
+- what the user's current type and past snapshots are
+- whether the app has been cleared
+
+## Why This Epic Matters
+
+Every user-facing epic depends on durable state.
+
+Without this layer, the app cannot reliably:
+
+- resume interrupted onboarding
+- resume interrupted daily sessions
+- enforce one daily session per local day
+- show history in Journal
+- show trends in Insights
+- support destructive controls in Settings
+
+This epic should give downstream developers confidence that the product can be closed, reopened, and used over time without losing state or creating contradictory records.
+
+## In Scope
+
+- Establish the persistent data structures needed for MVP
+- Persist question data or seeded question content in a way the app can consume reliably
+- Persist onboarding completion state
+- Persist onboarding sessions and responses
+- Persist daily sessions and responses
+- Persist derived type snapshots over time
+- Persist minimal app-level preferences required by MVP
+- Support initialization on first launch
+- Support recovery of in-progress sessions after app restart
+- Support queries needed by Today, Journal, Insights, and Settings
+- Support a full clear-data flow at the data level
+
+## Out of Scope
+
+- Cloud sync or multi-device consistency
+- User accounts or authentication
+- Notification scheduling
+- Analytics pipelines
+- Any UI implementation beyond what is needed for data validation
+
+## Required Outcomes
+
+### 1. Reliable First-Launch Initialization
+
+A clean install must initialize the app into a valid first-run state.
+
+That valid state must make it possible for the rest of the product to determine:
+
+- the app has not yet completed onboarding
+- the question catalog is available
+- no invalid partial records exist before the user starts interacting
+
+### 2. Durable Session History
+
+The platform must persist both onboarding and daily sessions in a way that supports:
+
+- starting a session
+- resuming a session
+- completing a session
+- loading a session by date or type
+- distinguishing in-progress from completed work
+
+### 3. Durable Answer History
+
+The platform must preserve each displayed question and each submitted answer so that the app can later reconstruct:
+
+- what the user saw
+- what the user answered
+- when the answer was recorded
+- which completed day the answer belongs to
+
+### 4. Durable Type State
+
+The app must be able to store or reconstruct the user's personality state over time.
+
+That includes:
+
+- the current accumulated type
+- axis-level scores or strength values
+- per-day type snapshots that power Journal and Insights
+
+### 5. Correct Daily Session Behavior
+
+The data layer must support the product rules that:
+
+- there is at most one daily session per local calendar day
+- a missed day is simply missed and does not create a backfillable gap
+- once a daily session is completed, no additional daily questions are created for that same day
+
+### 6. Destructive State Controls
+
+The data layer must make it possible to:
+
+- clear all local app data
+
+This action must leave the app in a coherent state rather than a partially cleared one.
+
+## Product Constraints
+
+- MVP storage is local-first and based on `SQLite`
+- The app must work without a network connection
+- Missed days are skipped permanently
+- Past completed answers are read-only in MVP
+- Daily sessions must be based on the user's local calendar day
+- The app must survive close and reopen behavior without losing valid work
+
+## Data Responsibilities
+
+At a minimum, the data platform must support the following product concepts:
+
+- app preferences and onboarding state
+- question catalog
+- onboarding sessions
+- daily sessions
+- session items or equivalent records linking questions to a specific session
+- recorded answers
+- type snapshots or equivalent derived state for history and insights
+
+The exact shape of the persistence model is left open as long as it cleanly supports the product behaviors.
+
+## Quality Expectations
+
+The data platform should favor correctness and recoverability.
+
+That means:
+
+- the app should not accidentally generate duplicate daily sessions
+- partial progress should not vanish after a restart
+- historical records should be queryable without hidden in-memory state
+- destructive actions should fully resolve into a known product state
+
+## Cross-Epic Dependencies
+
+This epic depends on Epic 01 for the question and scoring contracts.
+
+Other epics depend on this epic for:
+
+- onboarding persistence
+- daily session persistence
+- journal history queries
+- insights history and current type queries
+- settings clear-data actions
+
+## Isolation Guidance
+
+This epic can be completed largely in isolation.
+
+A developer working on this epic does not need finished versions of:
+
+- the onboarding screen
+- the swipe UI
+- the journal UI
+- the insights UI
+- the settings screen
+
+The work can be validated through seeded data, controlled flows, and direct product state transitions.
+
+## Acceptance Criteria
+
+1. A clean install initializes into a valid first-run state with onboarding incomplete and question data available.
+2. The app can persist onboarding progress so an interrupted onboarding flow can be resumed later without data loss.
+3. The app can persist a daily session so an interrupted daily check-in can be resumed later without data loss.
+4. The system enforces at most one daily session per local calendar day.
+5. Once a daily session is completed, reopening the app on the same day does not create a second session for that day.
+6. Completed sessions and their answers can be queried later by other parts of the product without relying on transient in-memory state.
+7. The data platform supports the product's ability to show both current overall type and historical daily snapshots.
+8. Clear local data returns the app to a fresh-install experience.
+9. The data layer works offline and does not require a backend service.
+
+## Validation Notes
+
+The person completing this epic should be able to demonstrate at least the following scenarios:
+
+- first launch before onboarding
+- partial onboarding, app close, and resume
+- partial daily session, app close, and resume
+- completed daily session and same-day reopen
+- multiple consecutive days with distinct completed sessions
+- clear data returning the app to first-launch behavior
+
+## Definition of Done
+
+This epic is done when the rest of the product can rely on local persistent data as the source of truth for onboarding state, daily check-ins, history, insights, and destructive clear-data behavior.

--- a/EPIC_03_APP_SHELL_AND_NAVIGATION.md
+++ b/EPIC_03_APP_SHELL_AND_NAVIGATION.md
@@ -1,0 +1,153 @@
+# Epic 03: App Shell and Navigation
+
+This document defines the top-level product structure for Swipe Check. It is derived from `PRODUCT_SPEC.md` in the project root.
+
+This epic is about getting the app into the right places at the right times. It intentionally avoids dictating component structure or exact navigation implementation details, as long as the product behavior is correct and consistent.
+
+## Project Context
+
+The current repository already contains an Expo Router application shell with starter tabs and demo content.
+
+The product, however, needs a purpose-built information architecture centered around:
+
+- onboarding for first-time users
+- a `Today` experience for the daily check-in
+- a `Journal` area for historical answers
+- an `Insights` area for current type and trends
+- a dedicated full-screen `Settings` page
+- an entry detail destination for viewing a specific completed day
+
+## Epic Goal
+
+Replace the starter shell with the real product shell so that a user with no prior state always lands in the correct flow and a returning user always lands in the correct product surface.
+
+At the end of this epic, the app should have a clear, product-aligned structure even if individual screens still use placeholder content.
+
+## Why This Epic Matters
+
+If the app shell is wrong, the rest of the work becomes difficult to validate.
+
+This epic establishes:
+
+- where onboarding lives
+- where the main product surfaces live
+- how Settings is reached
+- how historical detail is reached
+- which screen is the product's primary home
+- whether a user is incorrectly shown starter/demo content
+
+## In Scope
+
+- Define the product route structure
+- Replace starter navigation labels with product labels
+- Gate first-time users into onboarding
+- Route onboarded users into the main app
+- Establish the main tab structure for `Today`, `Journal`, and `Insights`
+- Expose `Settings` as a separate full-screen page
+- Expose a destination for viewing an individual journal entry or completed day
+- Ensure loading and transition states do not briefly expose the wrong screen
+
+## Out of Scope
+
+- Final onboarding UX details
+- Final swipe interaction implementation
+- Final Journal content rendering
+- Final Insights visualizations
+- Final Settings controls beyond route availability
+
+## Required Outcomes
+
+### 1. Correct First-Launch Routing
+
+When the app is opened by a brand-new user, the app must direct that user into the onboarding flow rather than the main product tabs.
+
+### 2. Correct Returning-User Routing
+
+When the app is opened by an onboarded user, the default destination should be the main app, with `Today` functioning as the primary home screen.
+
+### 3. Product-Aligned Main Navigation
+
+The main app navigation should reflect the actual product structure rather than generic starter naming.
+
+The user-facing primary destinations for MVP are:
+
+- `Today`
+- `Journal`
+- `Insights`
+
+### 4. Dedicated Settings Destination
+
+Settings should be a separate full-screen page, not a primary tab and not a transient modal.
+
+Users should be able to access it from the main app in a way that feels natural from the `Today` experience.
+
+### 5. Entry Detail Destination
+
+The shell must make room for a dedicated destination that can show the details of a specific completed day from Journal.
+
+### 6. No Starter Surface Leakage
+
+Starter routes, placeholder labels, or demo screens should not remain part of the user-facing product flow once this epic is complete.
+
+## Product Constraints
+
+- The `Today` screen is the main daily home of the app
+- The app must support both first-run and returning-user entry paths
+- Settings is a full-screen page
+- Journal and Insights are primary surfaces in MVP
+- Older completed days should be reachable from Journal through a dedicated detail destination
+
+## Current Repository Context
+
+As of this document, the repository contains starter-style screens and tabs. This epic should treat those as scaffolding rather than as part of the product definition.
+
+The outcome should be a navigation structure that matches the product vocabulary in `PRODUCT_SPEC.md`.
+
+## Cross-Epic Dependencies
+
+This epic depends on the app being able to determine onboarding state, whether through real persistence or temporary mocks.
+
+This epic unlocks clean validation for:
+
+- onboarding flow work
+- daily check-in work
+- Journal work
+- Insights work
+- Settings work
+
+## Isolation Guidance
+
+This epic can be completed in isolation using placeholder screen content and mocked state if necessary.
+
+A developer working on this epic does not need the final versions of:
+
+- question selection
+- scoring
+- persistence internals
+- charting
+
+The routing and navigation outcomes should still be correct even if the screen bodies are incomplete.
+
+## Acceptance Criteria
+
+1. A brand-new user is directed into onboarding rather than the main product tabs.
+2. An onboarded user lands in the main product flow with `Today` as the default home surface.
+3. The app exposes primary product navigation for `Today`, `Journal`, and `Insights`.
+4. `Settings` is available as a separate full-screen page rather than a main tab or temporary modal.
+5. The app provides a route or destination capable of showing details for an individual completed journal entry.
+6. Starter/demo route names and demo-first navigation labels are no longer part of the user-facing product shell.
+7. Loading or initialization states do not flash the wrong destination before redirecting the user.
+
+## Validation Notes
+
+The person completing this epic should be able to demonstrate at least the following:
+
+- app launch for a brand-new user
+- app launch for an onboarded user
+- access to `Today`, `Journal`, and `Insights`
+- access to `Settings` from the main app
+- navigation from Journal into a day detail destination
+
+## Definition of Done
+
+This epic is done when the app's outer structure matches the product's information architecture and users are always routed into the correct top-level flow.

--- a/EPIC_04_ONBOARDING_EXPERIENCE.md
+++ b/EPIC_04_ONBOARDING_EXPERIENCE.md
@@ -1,0 +1,161 @@
+# Epic 04: Onboarding Experience
+
+This document defines the first-run assessment experience for Swipe Check. It is derived from `PRODUCT_SPEC.md` in the project root.
+
+This epic focuses on the user experience and product behavior of onboarding. It does not prescribe a specific screen layout, animation approach, or state management pattern as long as the required outcomes are achieved.
+
+## Project Context
+
+Swipe Check is not a one-time quiz app. It is a daily `MBTI-style` journal that begins with a short onboarding assessment.
+
+The onboarding assessment exists to:
+
+- explain the app's core concept
+- establish the user's initial baseline
+- prevent the user from entering the main app without enough data to produce an initial type
+
+The onboarding assessment is fixed and includes exactly `12` questions.
+
+## Epic Goal
+
+Deliver a fast, understandable, one-time onboarding flow that introduces the product and creates the user's first `Current Type`.
+
+At the end of this epic, a brand-new user should be able to open the app, understand what they are about to do, complete all `12` onboarding questions, and enter the main app with an initial personality result already available.
+
+## Why This Epic Matters
+
+Onboarding is the user's first trust-building moment.
+
+If it is confusing, too long, or too abstract, users may leave before the daily habit loop ever begins.
+
+This epic should create an experience that feels:
+
+- lightweight
+- focused
+- comprehensible to a first-time user
+- aligned with the daily low-friction product promise
+
+## In Scope
+
+- The first-run onboarding entry experience
+- Introductory product framing for a new user
+- The `12` onboarding question flow
+- Visible progress through the onboarding session
+- Binary answer collection for onboarding questions
+- Persistence and resumption of an unfinished onboarding session
+- Completion behavior that generates the user's initial type and sends them into the main app
+
+## Out of Scope
+
+- Daily check-in flow after onboarding
+- Journal browsing
+- Insights screen design beyond whatever is needed to confirm onboarding success
+- Settings behavior
+- Reminder-related messaging
+
+## Required Outcomes
+
+### 1. First-Run Orientation
+
+The onboarding flow must tell the user what kind of app this is and what they are about to do.
+
+A user with no prior knowledge should understand that:
+
+- the app is a daily personality journal
+- onboarding is the initial baseline setup
+- answers are simple `Agree` or `Disagree` responses
+- the app will later present only `3` questions per day
+
+### 2. Fixed `12`-Question Assessment
+
+The onboarding session must contain exactly `12` questions.
+
+Those questions are fixed by the assessment rules and are not replaced by a random daily draw.
+
+### 3. Clear Progress Through the Flow
+
+The user should always understand that onboarding is finite and where they currently are within it.
+
+The flow should feel finishable.
+
+### 4. Durable Partial Progress
+
+If the app is interrupted during onboarding, the user should be able to return to the same onboarding session without losing valid completed answers.
+
+### 5. Valid Completion Transition
+
+When onboarding is completed:
+
+- the app must consider the user onboarded
+- the app must generate an initial personality result using the onboarding answers
+- the user must be able to enter the main app with that result available
+
+## Product Constraints
+
+- Onboarding happens once per install unless local data is cleared
+- The onboarding assessment uses binary responses only
+- Onboarding contains exactly `12` questions
+- No undo is provided after an onboarding answer is submitted
+- The result produced at the end of onboarding becomes the user's initial `Current Type`
+- The app should not imply the user is taking the official MBTI assessment
+
+## UX Expectations
+
+The onboarding flow should reinforce the app's low-friction premise.
+
+That means:
+
+- the flow should feel quick rather than academic
+- the answer choice should be obvious on every question
+- the user should not feel dropped into the main app without understanding what happened
+- completion should feel like a meaningful transition into the daily experience
+
+## Cross-Epic Dependencies
+
+This epic depends on:
+
+- Epic 01 for the onboarding question set and scoring rules
+- Epic 02 for durable session state or an equivalent persistent state source
+- Epic 03 for being routed into the onboarding flow correctly
+
+This epic provides a critical handoff into:
+
+- the main `Today` experience
+- the initial `Current Type` shown elsewhere in the app
+
+## Isolation Guidance
+
+This epic can be built and validated largely in isolation from the daily check-in and history surfaces.
+
+It does not require finished versions of:
+
+- the daily swipe flow
+- the journal list
+- the insights charts
+
+As long as the developer can start, resume, complete, and exit onboarding correctly, the epic can be considered independently successful.
+
+## Acceptance Criteria
+
+1. A brand-new user is required to complete onboarding before entering the main app.
+2. The onboarding experience explains the product clearly enough that a first-time user understands the purpose of the assessment and the app's daily habit model.
+3. The onboarding session contains exactly `12` questions.
+4. The user can answer each onboarding question using the app's binary response model without ambiguity.
+5. The onboarding flow clearly communicates progress so the user understands that the flow is finite.
+6. If the user leaves or closes the app mid-onboarding, the same unfinished onboarding session can be resumed later.
+7. Completing onboarding marks the user as onboarded and produces an initial `Current Type` that is available to the rest of the app.
+8. After onboarding completion, the user is transitioned into the main app rather than left in an undefined or repeated onboarding state.
+
+## Validation Notes
+
+The person completing this epic should be able to demonstrate at least the following:
+
+- first-ever launch into onboarding
+- visible progress through all `12` questions
+- interruption during onboarding and successful resume
+- final completion producing an initial type
+- entry into the main app after successful onboarding
+
+## Definition of Done
+
+This epic is done when a brand-new user can complete a one-time onboarding flow that establishes their initial personality baseline and cleanly hands them off into the daily product experience.

--- a/EPIC_05_DAILY_SWIPE_CHECK_IN.md
+++ b/EPIC_05_DAILY_SWIPE_CHECK_IN.md
@@ -1,0 +1,185 @@
+# Epic 05: Daily Swipe Check-In
+
+This document defines the core recurring interaction of Swipe Check. It is derived from `PRODUCT_SPEC.md` in the project root.
+
+This epic describes the user-visible behavior and business rules for the daily check-in. It does not prescribe a specific gesture library setup, animation system, component decomposition, or persistence implementation beyond what is already required by the product.
+
+## Project Context
+
+Swipe Check is built around a simple daily loop:
+
+- the user answers exactly `3` questions per day
+- each question uses only `Agree` or `Disagree`
+- the preferred interaction is a swipe gesture
+
+The daily check-in is the product's main habit-forming experience and is the default home of the app after onboarding.
+
+## Epic Goal
+
+Deliver the complete `Today` experience so that an onboarded user can open the app, complete today's `3` questions quickly, and immediately see that today's check-in is done.
+
+At the end of this epic, the core product promise should be real: a user can come back every day, answer a small number of swipeable prompts, and leave with confidence that their answers were saved and their profile was updated.
+
+## Why This Epic Matters
+
+This is the defining loop of the product.
+
+If this epic fails, the app is no longer a daily journal. It becomes either a broken quiz or a generic personality dashboard without a habit loop.
+
+This epic must make the daily action feel:
+
+- fast
+- obvious
+- reliable
+- worth repeating tomorrow
+
+## In Scope
+
+- The `Today` screen behavior for onboarded users
+- Creation or loading of today's daily session
+- Display of one question at a time
+- Clear `Agree` and `Disagree` submission behavior
+- Swipe-based answering as the primary interaction
+- Immediate persistence of submitted answers
+- Visible progress through today's `3` questions
+- Resume of unfinished daily sessions after interruption
+- Completed-today state after the third answer
+- Same-day reopen behavior after completion
+- Presentation of today's submitted answers and updated current type in the completed state
+
+## Out of Scope
+
+- The one-time onboarding flow
+- Full Journal browsing of previous days
+- Full Insights visualizations beyond what is needed for the completed-today state
+- Reminder scheduling
+- Editing historical answers
+
+## Required Outcomes
+
+### 1. Exactly One Daily Session Per Day
+
+For an onboarded user, the app must support at most one daily session per local calendar day.
+
+That session must contain exactly `3` questions.
+
+### 2. Primary Swipe-Based Submission
+
+The daily check-in should feel built around swiping.
+
+The app must make it obvious that:
+
+- swiping right means `Agree`
+- swiping left means `Disagree`
+
+The user should not need to guess which direction means what.
+
+### 3. Immediate Answer Persistence
+
+Once the user submits an answer, the app should treat it as recorded.
+
+If the user leaves the app partway through the daily session, previously submitted answers must remain intact.
+
+### 4. Resume of Incomplete Sessions
+
+If the user closes or backgrounds the app before finishing today's `3` questions, the next app open on that same day should return them to the unfinished session rather than generate a new one.
+
+### 5. Completed-Today State
+
+After the third answer is submitted, the `Today` surface must stop behaving like an active question flow and instead show a completed state for that day.
+
+That completed state should make it clear that:
+
+- today's questions are finished
+- today's answers can be reviewed easily
+- the user's current type is available and updated
+
+### 6. Missed-Day Behavior
+
+If the user does not open the app or does not complete a check-in on a given day, that day is missed.
+
+The product does not support backfilling missed daily sessions in MVP.
+
+## Product Constraints
+
+- The daily session contains exactly `3` questions
+- All daily answers use binary `Agree` or `Disagree`
+- Swipe is the primary interaction mode
+- No undo is provided after a daily answer is submitted
+- The user can submit answers only once per question shown in today's session
+- Completed daily sessions are read-only in MVP
+- Missed days are skipped permanently
+- The `Current Type` is based on all answers to date, including onboarding and completed daily responses
+
+## UX Expectations
+
+The daily flow should feel significantly lighter than a typical quiz.
+
+That means:
+
+- only one question should compete for the user's attention at a time
+- progress should be obvious
+- the action mapping for swipe directions should always be visible or otherwise unmistakable
+- the completed-today state should feel final rather than ambiguous
+
+## Edge Cases To Handle
+
+- The user opens the app before answering any of today's questions
+- The user answers one or two questions and leaves
+- The user returns later the same day after completion
+- The user misses a day entirely
+- The user completes onboarding and lands in `Today` for the first time
+
+The epic should resolve these states cleanly without creating duplicate daily sessions or confusing progress.
+
+## Cross-Epic Dependencies
+
+This epic depends on:
+
+- Epic 01 for daily selection and scoring rules
+- Epic 02 for persistent session state
+- Epic 03 for the `Today` route and product shell
+
+This epic produces data and behavior consumed by:
+
+- Journal
+- Insights
+- Settings clear-data validation
+
+## Isolation Guidance
+
+This epic can be executed largely in isolation from Journal and Insights as long as the developer can:
+
+- create or load today's session
+- move through the `3` questions
+- save answers
+- show the completed-today state
+
+The completed-today state may initially use lightweight or placeholder supporting visuals as long as the product behavior is correct.
+
+## Acceptance Criteria
+
+1. An onboarded user receives at most one daily session per local calendar day.
+2. Today's session contains exactly `3` questions.
+3. The `Today` experience makes the `Agree` and `Disagree` directions unambiguous.
+4. The user can submit each of today's answers through the intended swipe-based interaction.
+5. Each submitted answer is saved immediately enough that progress is not lost if the app is interrupted.
+6. An unfinished daily session can be resumed on the same day without generating a new set of questions.
+7. After the third answer, the `Today` screen shows a completed state rather than continuing to behave like an unfinished session.
+8. The completed state makes today's answers easy to review and shows the user's updated current type.
+9. Reopening the app later on the same day does not generate a second completed session for that day.
+10. Missing a day does not create a backfillable session and does not block future daily sessions.
+
+## Validation Notes
+
+The person completing this epic should be able to demonstrate at least the following:
+
+- first daily session after onboarding
+- answering all `3` questions in one sitting
+- partial progress, app close, and resume
+- completed-today reopen behavior
+- a missed day followed by a later successful daily session
+
+## Definition of Done
+
+This epic is done when the app's main daily habit loop is functional, trustworthy, and clearly limited to one completed `3`-question session per day.

--- a/EPIC_06_JOURNAL_AND_ENTRY_DETAIL.md
+++ b/EPIC_06_JOURNAL_AND_ENTRY_DETAIL.md
@@ -1,0 +1,162 @@
+# Epic 06: Journal and Entry Detail
+
+This document defines the read-only history experience for Swipe Check. It is derived from `PRODUCT_SPEC.md` in the project root.
+
+This epic is about helping the user look back at what they answered and how their result appeared on a given day. It does not prescribe a specific list design, grouping strategy, or layout implementation beyond the product outcomes described here.
+
+## Project Context
+
+Swipe Check is a daily journal, not just a current-score dashboard.
+
+Users need a place where they can review prior completed days without editing them. The product spec defines two important expectations:
+
+- today's answers should be easy to access
+- earlier answers should be accessible through some kind of list or menu flow
+
+Journal is the part of the app that makes the product feel cumulative rather than disposable.
+
+## Epic Goal
+
+Provide a clear, read-only history experience where users can browse completed days and inspect the details of a specific entry.
+
+At the end of this epic, a user should be able to move beyond the current day, open a past date, and understand what they answered and what type snapshot existed at that time.
+
+## Why This Epic Matters
+
+Without Journal, the app cannot feel like a journal.
+
+The user needs evidence that:
+
+- their answers are being retained
+- previous days remain accessible
+- personality history can be reviewed rather than guessed
+
+Journal is also the bridge between the raw act of answering questions and the later experience of spotting patterns.
+
+## In Scope
+
+- A Journal destination in the main product flow
+- A browsable list or menu of completed days
+- Clear surfacing of today's completed answers when available
+- A dedicated detail view for an individual completed day
+- Read-only display of the questions shown on that day
+- Read-only display of the user's answers for that day
+- Read-only display of that day's type snapshot or equivalent personality summary
+- Reasonable empty states when little or no daily history exists yet
+
+## Out of Scope
+
+- Editing past answers
+- Adding notes or mood tags
+- Advanced analytics or charting beyond a single day's snapshot
+- Reminder-related states
+- Backfilling missed days
+
+## Required Outcomes
+
+### 1. Browsable Completed-Day History
+
+The user must be able to see that prior completed days exist and choose one to inspect.
+
+The product does not require a specific visual pattern, but the resulting experience must make older entries discoverable rather than hidden behind unclear navigation.
+
+### 2. Clear Access to Today's Answers
+
+When the current day has been completed, today's answers should be easy to access.
+
+This does not require Journal to be the only place where today's answers are visible, but Journal must not make today's entry harder to find than older ones.
+
+### 3. Dedicated Entry Detail View
+
+Opening a completed day should reveal enough detail for the user to understand exactly what happened on that date.
+
+At minimum, a day detail view must show:
+
+- the date
+- the questions answered that day
+- the user's answers
+- the day's type snapshot or equivalent result summary
+
+### 4. Read-Only Historical State
+
+Completed history is not editable in MVP.
+
+The Journal experience should communicate review, not revision.
+
+### 5. Graceful Early-Lifecycle States
+
+The app must handle users with little or no history.
+
+Examples include:
+
+- a user who finished onboarding but has not completed any daily sessions yet
+- a user with only one or two completed daily sessions
+
+## Product Constraints
+
+- Journal is a primary surface in MVP
+- Past completed answers are read-only
+- Missed days are skipped, not backfilled
+- The app should not suggest that the user can edit or create entries for past missed dates
+
+## UX Expectations
+
+Journal should help the user answer simple questions such as:
+
+- What did I answer yesterday?
+- How did I show up last week?
+- What type did the app assign on a given day?
+
+The experience should feel like browsing a real timeline of completed participation, not a debug log of raw database records.
+
+## Edge Cases To Handle
+
+- No completed daily sessions yet
+- Only one completed daily session
+- Today completed but older history unavailable
+- Older history available across multiple dates
+- A missed day between completed days
+
+The presence of missed days must not imply that the user can go back and fill them in.
+
+## Cross-Epic Dependencies
+
+This epic depends on:
+
+- Epic 02 for persistent history data
+- Epic 03 for route structure and entry-detail navigation
+- Epic 05 for completed daily sessions to exist
+
+This epic provides an important read-only companion to the `Today` flow and supports the user's trust in the product.
+
+## Isolation Guidance
+
+This epic can be designed and developed largely against mocked or seeded history data.
+
+It does not require the final onboarding UI or final insights charts to be complete.
+
+What matters is that the Journal experience can consume completed-day data and present it in a coherent, read-only way.
+
+## Acceptance Criteria
+
+1. The app provides a Journal destination where the user can browse completed daily entries.
+2. Completed days are discoverable through a clear list or menu flow rather than being hidden behind unclear navigation.
+3. Today's completed answers, when available, are easy to locate from the Journal experience.
+4. Opening a completed day reveals the date, the questions shown that day, the user's answers, and that day's type snapshot or equivalent summary.
+5. Historical entries are read-only and do not present editing affordances in MVP.
+6. The Journal experience handles users with little or no history gracefully.
+7. The Journal experience does not imply that missed days can be backfilled.
+
+## Validation Notes
+
+The person completing this epic should be able to demonstrate at least the following:
+
+- Journal with no daily history
+- Journal with one completed day
+- Journal with multiple completed days
+- navigation from the Journal list into a day detail view
+- confirmation that past answers are reviewable but not editable
+
+## Definition of Done
+
+This epic is done when users can treat Swipe Check as a real history of completed daily check-ins rather than a one-screen experience with no durable record.

--- a/EPIC_07_INSIGHTS_AND_TYPE_VISUALIZATION.md
+++ b/EPIC_07_INSIGHTS_AND_TYPE_VISUALIZATION.md
@@ -1,0 +1,161 @@
+# Epic 07: Insights and Type Visualization
+
+This document defines the personality-summary and trend-viewing experience for Swipe Check. It is derived from `PRODUCT_SPEC.md` in the project root.
+
+This epic focuses on what the user must be able to understand from their accumulated answers. It does not prescribe a specific chart library, visual style, or axis component design as long as the resulting experience is clear, truthful, and aligned with the product model.
+
+## Project Context
+
+Swipe Check is not only a daily answer collection app. It also promises that users will be able to see:
+
+- their current type
+- the strength of each axis
+- how their personality profile changes over time
+
+The product uses binary answers and a running score model, so Insights must communicate useful patterns without overstating certainty or pretending the user is taking an official clinical instrument.
+
+## Epic Goal
+
+Deliver an Insights experience that translates raw answer history into understandable personality feedback.
+
+At the end of this epic, a user should be able to open Insights and answer questions like:
+
+- What is my current type?
+- Which letter on each axis is stronger right now?
+- Has my profile shifted over time?
+
+## Why This Epic Matters
+
+The app's promise is not just convenience. It is meaningful reflection.
+
+Without Insights, the app would collect answers without returning enough value. Users need a place where their accumulated participation is translated into something coherent and worth revisiting.
+
+## In Scope
+
+- A dedicated `Insights` destination in the main product flow
+- Display of the user's current overall type
+- Display of the four MBTI-style axis pairs:
+- `E / I`
+- `S / N`
+- `T / F`
+- `J / P`
+- Display of axis strength or confidence based on score differences
+- At least one time-based view that shows how personality results have changed over time
+- Graceful handling of limited-data states, such as a user with onboarding only or very little daily history
+
+## Out of Scope
+
+- Narrative AI interpretations
+- Social comparisons
+- Export/share features
+- Reminders
+- Advanced research-style statistics or scientific claims
+
+## Required Outcomes
+
+### 1. Clear Current Type Summary
+
+The user must be able to see a single `Current Type` derived from all answers to date.
+
+That includes:
+
+- onboarding answers
+- completed daily answers
+
+The current type shown in Insights must match the type used elsewhere in the product.
+
+### 2. Axis-Level Understanding
+
+The user must be able to see how the current type is formed across the four axis pairs.
+
+The product should make it possible to understand not just the letters, but how strongly the user's answer history currently leans toward one side of each axis.
+
+### 3. Time-Based Change Visibility
+
+The user must be able to see some form of change over time.
+
+The MVP does not require a complex analytics suite, but it does require at least one meaningful time-based view that helps the user understand movement rather than only a static snapshot.
+
+### 4. Honest Handling of Limited Data
+
+Insights must still function sensibly for users who have:
+
+- only completed onboarding
+- only completed a small number of daily sessions
+- sparse history overall
+
+The experience should avoid implying false precision when little data exists.
+
+When an axis pair is tied, Insights must use the shared product tie rule and retain the previously established axis letter rather than inventing a separate display rule.
+
+## Product Constraints
+
+- The app presents a single `Current Type`
+- Type calculation is based on all answers to date
+- Axis strength is based on the scoring gap between poles
+- Tied axis pairs must retain their previously established value according to the shared scoring model
+- Insights is an MVP surface, so the initial visualizations should stay simple and understandable
+- The product is `MBTI-style`, not the official MBTI assessment
+
+## UX Expectations
+
+Insights should make the user feel informed, not lectured.
+
+The experience should:
+
+- be easy to scan quickly
+- explain what is current versus historical
+- avoid overclaiming certainty
+- reinforce the idea that the profile is built from repeated small check-ins over time
+
+## Edge Cases To Handle
+
+- Onboarding completed but no daily sessions yet
+- Only one or two daily sessions completed
+- Larger history with multiple snapshots over time
+- Axis values that are very close or tied
+
+The screen should remain coherent in all of these cases.
+
+## Cross-Epic Dependencies
+
+This epic depends on:
+
+- Epic 01 for scoring and axis rules
+- Epic 02 for historical snapshots and current score availability
+- Epic 03 for the main `Insights` destination
+- Epic 05 for daily data to accumulate over time
+
+This epic complements Journal by focusing on interpretation and trend visibility rather than raw day-by-day review.
+
+## Isolation Guidance
+
+This epic can be built in isolation using mocked or seeded score histories.
+
+It does not require the final swipe interaction to be complete as long as representative data exists.
+
+What matters is that the Insights experience can correctly consume the score model and communicate it clearly.
+
+## Acceptance Criteria
+
+1. The app provides an `Insights` destination where the user can see their current overall type.
+2. The current type shown in Insights matches the score model used throughout the rest of the app.
+3. The user can view all four axis pairs and understand which side of each axis currently has the stronger score.
+4. The screen presents axis strength or confidence in a way that reflects score differences rather than only showing four letters with no supporting context.
+5. The screen includes at least one meaningful time-based view that shows how the user's results have changed over time.
+6. The screen remains usable and understandable for users with minimal history, including users with onboarding only.
+7. The Insights experience does not imply that the app is using the official MBTI questionnaire or making stronger claims than the available data supports.
+
+## Validation Notes
+
+The person completing this epic should be able to demonstrate at least the following:
+
+- a user with onboarding only
+- a user with a few completed daily sessions
+- a user with longer history and multiple snapshots
+- visible axis strength information
+- a time-based view that communicates change over time
+
+## Definition of Done
+
+This epic is done when users can open Insights and understand both their current personality profile and how that profile has evolved through repeated daily participation.

--- a/EPIC_08_SETTINGS_AND_LOCAL_DATA_CONTROLS.md
+++ b/EPIC_08_SETTINGS_AND_LOCAL_DATA_CONTROLS.md
@@ -1,0 +1,143 @@
+# Epic 08: Settings and Local Data Controls
+
+This document defines the MVP settings experience for Swipe Check. It is derived from `PRODUCT_SPEC.md` in the project root.
+
+This epic is intentionally limited to the controls already included in MVP. It does not prescribe how the page is laid out or how confirmation interactions are implemented, only what user-visible outcomes must exist.
+
+## Project Context
+
+Swipe Check includes a dedicated full-screen `Settings` page in MVP.
+
+The purpose of Settings in MVP is operational, not expansive. It exists so the user can:
+
+- view basic app information
+- clear local app data entirely
+
+The product explicitly keeps reminders, cloud sync, and account management out of MVP.
+
+## Epic Goal
+
+Provide a dedicated, trustworthy settings area where users can access app information and safely perform the limited local-data actions supported in MVP.
+
+At the end of this epic, a user should be able to open Settings from the main app, understand what controls are available, and perform the destructive local-data action without being left in a confusing or contradictory state.
+
+## Why This Epic Matters
+
+Even a small MVP needs a place for app-level controls.
+
+Without Settings:
+
+- local-data controls are hidden or unavailable
+- local data cannot be safely cleared
+- testing and QA flows become harder
+- the product has no obvious place for future non-core controls
+
+This epic also establishes the boundary between the current MVP and future features such as reminders and Supabase sync.
+
+## In Scope
+
+- A dedicated full-screen `Settings` page
+- Access to Settings from the main app
+- Basic app information, including version or equivalent app identity information
+- A user-facing action to clear all local data
+- Confirmation or other explicit user intent handling for destructive actions
+- Coherent post-action app state after clear-data operations
+
+## Out of Scope
+
+- Local reminders
+- Notification permissions
+- Account creation or sign-in
+- Supabase or cloud sync controls
+- Theme customization
+- Notes, export, or social settings
+
+## Required Outcomes
+
+### 1. Dedicated Full-Screen Settings Experience
+
+Settings must be its own full-screen destination rather than a modal or primary tab.
+
+It should feel like a deliberate app-level destination rather than an incidental overlay.
+
+### 2. Basic App Information
+
+The user should be able to see basic app-level information such as version or equivalent identifying details.
+
+This helps both real users and QA flows understand what build they are using.
+
+### 3. Clear Local Data Action
+
+The app must provide a full local wipe action that returns the app to a fresh-install state.
+
+After this action, the user should experience the app as though it has no existing local history.
+
+### 4. Safe Destructive Flows
+
+Clear local data is a destructive action.
+
+The app must require explicit user intent before carrying it out.
+
+## Product Constraints
+
+- Settings is part of MVP
+- Settings is a full-screen page
+- Local reminders are post-MVP and must not appear as shipped MVP commitments
+- The app must remain coherent after clear-data actions
+- Clear local data must return the app to first-launch behavior
+
+## UX Expectations
+
+Settings should feel calm and trustworthy.
+
+The page should make it easy for the user to understand:
+
+- what the action does
+- whether it is reversible
+- what state the app will be in afterward
+
+The destructive action should never feel accidental.
+
+## Edge Cases To Handle
+
+- Clear local data from any current app state
+- Returning to the app immediately after a destructive action
+
+The user must never see contradictory state after clearing data. Once the wipe completes, the app should behave like a fresh install.
+
+## Cross-Epic Dependencies
+
+This epic depends on:
+
+- Epic 02 for persistent data clear capabilities
+- Epic 03 for routing to Settings from the main app
+
+This epic is intentionally light on dependencies from the feature surfaces. It can be developed and validated independently once the necessary data actions exist.
+
+## Isolation Guidance
+
+This epic can be completed largely in isolation from Journal and Insights.
+
+The main requirement is that the settings surface can trigger the correct product-level state transitions and that those transitions are reflected clearly when the user returns to the app.
+
+## Acceptance Criteria
+
+1. The app provides a separate full-screen `Settings` destination reachable from the main product flow.
+2. Settings shows basic app information such as version or equivalent identifying details.
+3. Settings provides a clear local data action.
+4. After clearing local data, the app behaves like a fresh install with no prior local history.
+5. Destructive actions require explicit user intent before they are executed.
+6. The MVP Settings page does not expose post-MVP features such as reminders, sync, or account management as if they were already supported.
+
+## Validation Notes
+
+The person completing this epic should be able to demonstrate at least the following:
+
+- opening Settings from the main app
+- viewing app information
+- triggering clear local data and observing the resulting first-launch state
+- confirmation behavior before destructive actions complete
+
+## Definition of Done
+
+This epic is done when the app has a dedicated settings surface that safely exposes the limited local controls required for MVP and leaves the app in a coherent state after clear local data is used.

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -1,0 +1,96 @@
+# Swipe Check Product Spec
+
+## Product Summary
+
+Swipe Check is a local-first, `MBTI-style` personality journal built around a fast daily swipe interaction.
+
+Instead of asking the user to complete a long personality test in one sitting, the app establishes an initial baseline during onboarding and then continues through small daily check-ins. The product is meant to feel lightweight, repeatable, and reflective rather than academic or exhausting.
+
+## Product Goals
+
+- Make daily personality reflection quick and low-friction
+- Encourage repeat use through short sessions and clear interaction patterns
+- Help users understand their current type and how it changes over time
+- Keep the MVP simple, offline-capable, and usable without accounts
+
+## MVP Overview
+
+The MVP includes:
+
+- A one-time onboarding assessment
+- A daily `Today` experience with swipe-based answering
+- A `Journal` for reviewing completed entries
+- An `Insights` area for current type and trend visibility
+- A full-screen `Settings` page for app info and clear-data controls
+- Local persistence using `SQLite`
+
+The MVP does not include:
+
+- Accounts, auth, or cloud sync
+- Reminders or notification scheduling
+- Editing past answers or backfilling missed days
+- Notes, mood tags, export, sharing, or social features
+- Advanced interpretation beyond the core score and trend model
+
+## Core Product Rules
+
+- All answers are binary: `Agree` or `Disagree`
+- Onboarding must be completed before the user enters the main app
+- Onboarding contains `12` questions
+- Daily check-ins contain `3` questions per local calendar day
+- There is at most one daily session per local day
+- Missed days are skipped in MVP
+- No undo is provided during active sessions in MVP
+- Completed historical answers are read-only in MVP
+- The app presents a single `Current Type` derived from the user's accumulated answer history
+
+## Primary User Flows
+
+### First Launch
+
+The user completes onboarding, receives an initial `Current Type`, and then enters the main app.
+
+### Returning Daily Use
+
+The user opens `Today`, completes that day's check-in, and then sees a completed state rather than a new set of questions.
+
+### History Review
+
+The user can browse completed entries in `Journal` and open a specific entry to review that day's questions, answers, and stored type state.
+
+### Insights Review
+
+The user can open `Insights` to see their `Current Type`, axis-level summary, and time-based changes.
+
+### App Controls
+
+The user can open `Settings` to view app information or clear local data.
+
+## Information Architecture
+
+The MVP product surfaces are:
+
+- `Today`
+- `Journal`
+- `Insights`
+- `Settings`
+- An entry detail destination for viewing a specific completed day
+
+## Detailed Requirements By Epic
+
+Detailed product requirements live in the epic documents:
+
+- `EPIC_01_QUESTION_BANK_AND_ASSESSMENT_RULES.md`: question contract, onboarding set, daily selection, scoring, and snapshots
+- `EPIC_02_LOCAL_DATA_PLATFORM.md`: local persistence, session durability, and clear-data support
+- `EPIC_03_APP_SHELL_AND_NAVIGATION.md`: routing, app shell, and top-level navigation
+- `EPIC_04_ONBOARDING_EXPERIENCE.md`: first-run onboarding flow and onboarding completion behavior
+- `EPIC_05_DAILY_SWIPE_CHECK_IN.md`: `Today` screen behavior, swipe submission, resume, and completed-day state
+- `EPIC_06_JOURNAL_AND_ENTRY_DETAIL.md`: read-only history browsing and per-entry detail behavior
+- `EPIC_07_INSIGHTS_AND_TYPE_VISUALIZATION.md`: current type, axis strength, and trend visibility
+- `EPIC_08_SETTINGS_AND_LOCAL_DATA_CONTROLS.md`: settings behavior and clear local data flow
+
+## Product Notes
+
+- Swipe Check should be described as `MBTI-style`, not as the official MBTI assessment
+- Public-facing copy should avoid official proprietary MBTI questionnaire language
+- Detailed question logic, scoring rules, persistence design, and screen-level acceptance criteria belong in the epic documents rather than in this overview


### PR DESCRIPTION
## Summary
- add the product spec and eight epic documents to the repository
- simplify `PRODUCT_SPEC.md` into a high-level overview and move detailed rules into the epic docs
- document the agreed MVP decisions, including separate onboarding/daily pools, no onboarding reset, no undo, deterministic daily selection, and tie handling that retains the previous axis value