### PR TITLE
Follow-up: add daily-selection tests and validation examples for Epic 01.6

### DIFF
--- a/__tests__/daily-selection-test.ts
+++ b/__tests__/daily-selection-test.ts
@@ -1,0 +1,121 @@
+import {
+  createEmptyAxisExposure,
+  selectDailyQuestions,
+  updateAxisExposure,
+  updateQuestionLastUsed,
+  type QuestionLastUsedMap,
+} from '@/constants/daily-selection';
+
+describe('daily question selection policy', () => {
+  it('selects one question from each of the 3 least-exposed axes using fixed axis order when tied', () => {
+    const selection = selectDailyQuestions({
+      today: '2026-03-31',
+      axisExposure: {
+        'e-i': 0,
+        's-n': 0,
+        't-f': 0,
+        'j-p': 0,
+      },
+      questionLastUsed: {},
+    });
+
+    expect(selection.questions).toHaveLength(3);
+    expect(selection.selectedAxisIds).toEqual(['e-i', 's-n', 't-f']);
+    expect(new Set(selection.questions.map((q) => q.axisId))).toEqual(
+      new Set(['e-i', 's-n', 't-f'])
+    );
+  });
+
+  it('uses axis recency tie-breakers before falling back to fixed axis order', () => {
+    const lastUsed: QuestionLastUsedMap = {
+      // E/I most recently shown axis
+      'q-013': 400,
+      'q-017': 400,
+      'q-018': 400,
+      'q-019': 400,
+      // S/N
+      'q-014': 300,
+      'q-020': 300,
+      'q-021': 300,
+      'q-022': 300,
+      // T/F
+      'q-015': 200,
+      'q-023': 200,
+      'q-024': 200,
+      'q-025': 200,
+      // J/P least recently shown axis
+      'q-016': 100,
+      'q-026': 100,
+      'q-027': 100,
+      'q-028': 100,
+    };
+
+    const selection = selectDailyQuestions({
+      today: '2026-03-31',
+      axisExposure: createEmptyAxisExposure(),
+      questionLastUsed: lastUsed,
+    });
+
+    expect(selection.selectedAxisIds).toEqual(['j-p', 't-f', 's-n']);
+    expect(selection.metadata.tieBreakersUsed.length).toBeGreaterThan(0);
+  });
+
+  it('avoids repeating yesterday question IDs when another valid axis question exists', () => {
+    const selection = selectDailyQuestions({
+      today: '2026-03-31',
+      axisExposure: {
+        'e-i': 0,
+        's-n': 0,
+        't-f': 0,
+        'j-p': 10,
+      },
+      questionLastUsed: {
+        'q-013': 1,
+        'q-014': 1,
+        'q-015': 1,
+      },
+      yesterdaySession: {
+        date: '2026-03-30',
+        questionIds: ['q-013', 'q-014', 'q-015'],
+      },
+    });
+
+    expect(selection.selectedAxisIds).toEqual(['e-i', 's-n', 't-f']);
+    expect(selection.questions.map((q) => q.id)).not.toEqual(
+      expect.arrayContaining(['q-013', 'q-014', 'q-015'])
+    );
+  });
+});
+
+describe('daily selection tracking helpers', () => {
+  it('updates per-axis exposure counts from completed question IDs', () => {
+    const nextExposure = updateAxisExposure(createEmptyAxisExposure(), [
+      'q-013', // e-i
+      'q-014', // s-n
+      'q-023', // t-f
+      'q-016', // j-p
+      'q-026', // j-p
+    ]);
+
+    expect(nextExposure).toEqual({
+      'e-i': 1,
+      's-n': 1,
+      't-f': 1,
+      'j-p': 2,
+    });
+  });
+
+  it('records a last-used timestamp for each completed question', () => {
+    const updated = updateQuestionLastUsed(
+      { 'q-013': 10 },
+      ['q-013', 'q-020', 'q-023'],
+      123456,
+    );
+
+    expect(updated).toEqual({
+      'q-013': 123456,
+      'q-020': 123456,
+      'q-023': 123456,
+    });
+  });
+});

--- a/docs/epic-01-validation-examples.md
+++ b/docs/epic-01-validation-examples.md
@@ -1,0 +1,65 @@
+# Epic 01.6 Validation Examples
+
+These examples are concrete, deterministic checks for onboarding scoring, daily selection behavior, and edge cases.
+
+## 1) Onboarding scoring output example
+
+### Input history (12 onboarding answers)
+
+- E/I: `q-001 agree`, `q-002 disagree`, `q-003 disagree` → E=2, I=1
+- S/N: `q-004 agree`, `q-005 disagree`, `q-006 agree` → S=3, N=0
+- T/F: `q-007 agree`, `q-008 agree`, `q-009 disagree` → T=1, F=2
+- J/P: `q-010 agree`, `q-011 disagree`, `q-012 disagree` → J=2, P=1
+
+### Expected output
+
+- `typeCode`: `ESFJ`
+- `isComplete`: `true`
+- `axesWithMinimumData`: `4`
+- `totalAnswers`: `12`
+
+This scenario is covered by automated tests in `__tests__/scoring-test.ts`.
+
+## 2) Daily selection examples
+
+### A. Full tie on exposure and recency fallback
+
+When all axes have identical exposure and no recent-usage signal, selection order uses the fixed axis order:
+
+1. `e-i`
+2. `s-n`
+3. `t-f`
+4. `j-p`
+
+Expected selected axes for the day: `['e-i', 's-n', 't-f']`.
+
+### B. Exposure tie broken by least-recently-used axis
+
+If exposures are tied but axis recency differs, the least recently shown axis is selected first.
+
+Example recency ranking: `j-p` least recent, then `t-f`, then `s-n`, and `e-i` most recent.
+
+Expected selected axes for the day: `['j-p', 't-f', 's-n']`.
+
+### C. Avoid repeating yesterday when alternatives exist
+
+If yesterday used `q-013`, `q-014`, `q-015`, selection for the same axes should choose alternatives on those axes when available.
+
+Expected: selected IDs for `e-i`, `s-n`, and `t-f` do **not** include those three IDs.
+
+These scenarios are covered by automated tests in `__tests__/daily-selection-test.ts`.
+
+## 3) Edge-case examples
+
+### A. Tied axis retains prior letter
+
+- Baseline: E/I has E=3, I=0 → letter `E`
+- Later history: E/I becomes E=3, I=3 (tied)
+- Expected display letter remains `E` using retention tie-breaker.
+
+### B. Low-data honesty
+
+- With no answers: type is `XXXX`, `axesWithMinimumData=0`, `isComplete=false`
+- With only two answers on one axis: that axis has `hasMinimumData=false`
+
+These scenarios are covered by automated tests in `__tests__/scoring-test.ts`.


### PR DESCRIPTION
### Motivation
- Provide concrete, reviewer-friendly validation for Epic 01.6 so assessment rules can be verified without reverse-engineering code. 
- Add executable coverage for the daily selection policy and human-readable examples for onboarding and edge-case scoring behavior.

### Description
- Added `__tests__/daily-selection-test.ts` with tests for deterministic axis selection, recency-based tie-breaking, yesterday-repeat avoidance, and the `updateAxisExposure`/`updateQuestionLastUsed` helpers. 
- Added `docs/epic-01-validation-examples.md` containing worked examples for onboarding scoring (`ESFJ` scenario), daily selection scenarios, tied-axis retention, and low-data honesty. 
- Tests and examples reference the existing selection API (`selectDailyQuestions`, `createEmptyAxisExposure`) and the canonical question set to ensure alignment with the spec.

### Testing
- Ran `pnpm lint` and `pnpm typecheck` with no errors. 
- Ran `pnpm test:ci` which executed the full suite and passed all test suites (5 passed, 5 total). 
- The new tests assert the daily selection behavior and helper updates and are included in the passing CI run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0780f27c8320b97e31d3dd44c118)