### PR TITLE
Fix daily selection balance and snapshot validation

### DIFF
--- a/__tests__/daily-selection-test.ts
+++ b/__tests__/daily-selection-test.ts
@@ -1,5 +1,6 @@
 import {
   createEmptyAxisExposure,
+  createEmptyAxisPoleExposure,
   selectDailyQuestions,
   updateAxisExposure,
   updateQuestionLastUsed,
@@ -16,6 +17,7 @@ describe('daily question selection policy', () => {
         't-f': 0,
         'j-p': 0,
       },
+      axisPoleExposure: createEmptyAxisPoleExposure(),
       questionLastUsed: {},
     });
 
@@ -53,11 +55,50 @@ describe('daily question selection policy', () => {
     const selection = selectDailyQuestions({
       today: '2026-03-31',
       axisExposure: createEmptyAxisExposure(),
+      axisPoleExposure: createEmptyAxisPoleExposure(),
       questionLastUsed: lastUsed,
     });
 
     expect(selection.selectedAxisIds).toEqual(['j-p', 't-f', 's-n']);
     expect(selection.metadata.tieBreakersUsed.length).toBeGreaterThan(0);
+  });
+
+  it('prefers the less-used coding direction before recency within an axis', () => {
+    const selection = selectDailyQuestions({
+      today: '2026-03-31',
+      axisExposure: createEmptyAxisExposure(),
+      axisPoleExposure: {
+        'e-i': { e: 5, i: 1 },
+        's-n': { s: 5, n: 1 },
+        't-f': { t: 1, f: 5 },
+        'j-p': { j: 0, p: 0 },
+      },
+      questionLastUsed: {
+        'q-013': 10,
+        'q-019': 20,
+        'q-017': 100,
+        'q-018': 90,
+        'q-014': 10,
+        'q-020': 20,
+        'q-021': 100,
+        'q-022': 90,
+        'q-015': 10,
+        'q-024': 20,
+        'q-023': 100,
+        'q-025': 110,
+        'q-016': 300,
+        'q-026': 300,
+        'q-027': 300,
+        'q-028': 300,
+      },
+    });
+
+    expect(selection.selectedAxisIds).toEqual(['e-i', 's-n', 't-f']);
+    expect(selection.questions.map((q) => q.id)).toEqual([
+      'q-018',
+      'q-022',
+      'q-023',
+    ]);
   });
 
   it('avoids repeating yesterday question IDs when another valid axis question exists', () => {
@@ -69,6 +110,7 @@ describe('daily question selection policy', () => {
         't-f': 0,
         'j-p': 10,
       },
+      axisPoleExposure: createEmptyAxisPoleExposure(),
       questionLastUsed: {
         'q-013': 1,
         'q-014': 1,
@@ -81,9 +123,9 @@ describe('daily question selection policy', () => {
     });
 
     expect(selection.selectedAxisIds).toEqual(['e-i', 's-n', 't-f']);
-    expect(selection.questions.map((q) => q.id)).not.toEqual(
-      expect.arrayContaining(['q-013', 'q-014', 'q-015'])
-    );
+    expect(selection.questions.map((q) => q.id)).not.toContain('q-013');
+    expect(selection.questions.map((q) => q.id)).not.toContain('q-014');
+    expect(selection.questions.map((q) => q.id)).not.toContain('q-015');
   });
 });
 

--- a/__tests__/scoring-test.ts
+++ b/__tests__/scoring-test.ts
@@ -350,6 +350,33 @@ describe('calculateType', () => {
         result2.axes.map((a) => a.winningPoleId)
       );
     });
+
+    it('should validate provided snapshot history when present', () => {
+      const session1Answers = [
+        createAnswer('q-001', 'agree'),
+        createAnswer('q-004', 'agree'),
+        createAnswer('q-007', 'agree'),
+      ];
+
+      const session2Answers = [
+        ...session1Answers,
+        createAnswer('q-002', 'disagree'),
+        createAnswer('q-005', 'agree'),
+        createAnswer('q-008', 'disagree'),
+      ];
+
+      const result1 = calculateType(session1Answers);
+      const result2 = calculateType(session2Answers, { previousResult: result1 });
+      const snapshot1 = createTypeSnapshot(result1, 'session-1');
+      const snapshot2 = createTypeSnapshot(result2, 'session-2');
+
+      expect(() =>
+        recalculateTypeHistory(
+          [snapshot1, { ...snapshot2, typeCode: 'XXXX' }],
+          [session1Answers, session2Answers]
+        )
+      ).toThrow('Snapshot history does not match answer history at index 1.');
+    });
   });
 
   describe('Model honesty', () => {

--- a/constants/daily-selection.ts
+++ b/constants/daily-selection.ts
@@ -1,11 +1,17 @@
 import type { Question } from './question-contract';
-import { QUESTIONS } from './questions';
+import { AXES, QUESTIONS } from './questions';
 
 /**
  * Axis exposure tracking.
  * Maps axis ID to count of how many times it has appeared in completed daily sessions.
  */
 export type AxisExposureMap = Record<string, number>;
+
+/**
+ * Axis pole exposure tracking.
+ * Maps axis ID to per-pole usage counts across completed daily sessions.
+ */
+export type AxisPoleExposureMap = Record<string, Record<string, number>>;
 
 /**
  * Question usage tracking.
@@ -31,6 +37,8 @@ export type DailySelectionInput = {
   today: string;
   /** Axis exposure counts across all completed daily sessions */
   axisExposure: AxisExposureMap;
+  /** Per-pole usage counts across all completed daily sessions */
+  axisPoleExposure?: AxisPoleExposureMap;
   /** Last used timestamp for each question */
   questionLastUsed: QuestionLastUsedMap;
   /** Yesterday's session history (to avoid repetition) */
@@ -80,6 +88,17 @@ function getActiveDailyQuestionsForAxis(axisId: string): Question[] {
 }
 
 /**
+ * Gets the exposure count for a specific pole on an axis.
+ */
+function getAxisPoleExposureCount(
+  axisPoleExposure: AxisPoleExposureMap,
+  axisId: string,
+  poleId: string
+): number {
+  return axisPoleExposure[axisId]?.[poleId] ?? 0;
+}
+
+/**
  * Sorts axis IDs by exposure (ascending), then by recency (least recent first),
  * then by fixed axis order.
  */
@@ -123,10 +142,12 @@ function sortAxesBySelectionPriority(
 
 /**
  * Selects the best question for an axis based on usage history.
- * Prefers least-recently-used questions and avoids yesterday's question.
+ * Prefers the least-used coding direction first, then least-recently-used questions,
+ * and avoids yesterday's question when possible.
  */
 function selectQuestionForAxis(
   axisId: string,
+  axisPoleExposure: AxisPoleExposureMap,
   questionLastUsed: QuestionLastUsedMap,
   yesterdayQuestionIds: string[]
 ): Question | null {
@@ -142,8 +163,20 @@ function selectQuestionForAxis(
   );
   const candidates = alternatives.length > 0 ? alternatives : axisQuestions;
 
+  // Prefer the least-used coding direction for the axis before recency.
+  const leastUsedDirectionExposure = Math.min(
+    ...candidates.map((question) =>
+      getAxisPoleExposureCount(axisPoleExposure, axisId, question.agreePoleId)
+    )
+  );
+  const directionBalancedCandidates = candidates.filter(
+    (question) =>
+      getAxisPoleExposureCount(axisPoleExposure, axisId, question.agreePoleId) ===
+      leastUsedDirectionExposure
+  );
+
   // Sort by last used timestamp (ascending - least recent first)
-  const sorted = [...candidates].sort((a, b) => {
+  const sorted = [...directionBalancedCandidates].sort((a, b) => {
     const lastUsedA = questionLastUsed[a.id] ?? 0;
     const lastUsedB = questionLastUsed[b.id] ?? 0;
     return lastUsedA - lastUsedB;
@@ -163,7 +196,14 @@ function selectQuestionForAxis(
 export function selectDailyQuestions(
   input: DailySelectionInput
 ): DailySelectionResult {
-  const { axisExposure, questionLastUsed, yesterdaySession } = input;
+  const {
+    axisExposure,
+    axisPoleExposure,
+    questionLastUsed,
+    yesterdaySession,
+  } = input;
+  const resolvedAxisPoleExposure =
+    axisPoleExposure ?? createEmptyAxisPoleExposure();
   const activeDailyQuestions = getActiveDailyQuestions();
   const yesterdayQuestionIds = yesterdaySession?.questionIds ?? [];
 
@@ -200,6 +240,7 @@ export function selectDailyQuestions(
   for (const axisId of selectedAxisIds) {
     const question = selectQuestionForAxis(
       axisId,
+      resolvedAxisPoleExposure,
       questionLastUsed,
       yesterdayQuestionIds
     );
@@ -231,6 +272,21 @@ export function createEmptyAxisExposure(): AxisExposureMap {
 }
 
 /**
+ * Creates an empty per-pole exposure map with all axis poles initialized to 0.
+ */
+export function createEmptyAxisPoleExposure(): AxisPoleExposureMap {
+  return Object.fromEntries(
+    AXES.map((axis) => [
+      axis.id,
+      {
+        [axis.poleA.id]: 0,
+        [axis.poleB.id]: 0,
+      },
+    ])
+  ) as AxisPoleExposureMap;
+}
+
+/**
  * Updates axis exposure counts after a daily session is completed.
  */
 export function updateAxisExposure(
@@ -243,6 +299,32 @@ export function updateAxisExposure(
     const question = QUESTIONS.find((q) => q.id === questionId);
     if (question && question.axisId) {
       newExposure[question.axisId] = (newExposure[question.axisId] ?? 0) + 1;
+    }
+  }
+
+  return newExposure;
+}
+
+/**
+ * Updates per-pole exposure counts after a daily session is completed.
+ */
+export function updateAxisPoleExposure(
+  currentExposure: AxisPoleExposureMap,
+  completedQuestionIds: string[]
+): AxisPoleExposureMap {
+  const newExposure: AxisPoleExposureMap = {};
+
+  for (const [axisId, poleExposure] of Object.entries(currentExposure)) {
+    newExposure[axisId] = { ...poleExposure };
+  }
+
+  for (const questionId of completedQuestionIds) {
+    const question = QUESTIONS.find((q) => q.id === questionId);
+    if (question && question.axisId) {
+      const axisExposure = newExposure[question.axisId] ?? {};
+      axisExposure[question.agreePoleId] =
+        (axisExposure[question.agreePoleId] ?? 0) + 1;
+      newExposure[question.axisId] = axisExposure;
     }
   }
 

--- a/constants/scoring.ts
+++ b/constants/scoring.ts
@@ -298,12 +298,53 @@ export function recalculateTypeHistory(
   snapshots: TypeSnapshot[],
   allAnswers: AnsweredQuestion[][]
 ): TypeResult[] {
+  if (snapshots.length > 0 && snapshots.length !== allAnswers.length) {
+    throw new Error('Snapshot history must align with answer history.');
+  }
+
   const results: TypeResult[] = [];
   let previousResult: TypeResult | undefined;
 
   for (let i = 0; i < allAnswers.length; i++) {
     const answers = allAnswers[i];
-    const result = calculateType(answers, { previousResult });
+    const snapshot = snapshots[i];
+    const result = calculateType(answers, {
+      previousResult,
+      computedAt: snapshot?.computedAt,
+    });
+
+    if (snapshot) {
+      const matchesSnapshot =
+        result.typeCode === snapshot.typeCode &&
+        result.totalAnswers === snapshot.totalAnswers &&
+        result.axesWithMinimumData === snapshot.axesWithMinimumData &&
+        result.isComplete === snapshot.isComplete &&
+        result.axes.length === snapshot.axes.length &&
+        result.axes.every((axis, index) => {
+          const snapshotAxis = snapshot.axes[index];
+          if (!snapshotAxis) {
+            return false;
+          }
+
+          return (
+            axis.axisId === snapshotAxis.axisId &&
+            axis.winningPoleId === snapshotAxis.winningPoleId &&
+            axis.displayLetter === snapshotAxis.displayLetter &&
+            axis.poleACount === snapshotAxis.poleACount &&
+            axis.poleBCount === snapshotAxis.poleBCount &&
+            axis.totalAnswers === snapshotAxis.totalAnswers &&
+            axis.strength === snapshotAxis.strength &&
+            axis.hasMinimumData === snapshotAxis.hasMinimumData &&
+            axis.wasTieBroken === snapshotAxis.wasTieBroken
+          );
+        }) &&
+        result.computedAt.getTime() === snapshot.computedAt.getTime();
+
+      if (!matchesSnapshot) {
+        throw new Error(`Snapshot history does not match answer history at index ${i}.`);
+      }
+    }
+
     results.push(result);
     previousResult = result;
   }


### PR DESCRIPTION
## Summary
- Balance daily question selection by tracking per-axis coding direction exposure before recency tie-breaking.
- Validate snapshot history during type recalculation instead of ignoring the provided snapshots array.
- Tighten daily selection and scoring tests to cover the regressions directly.

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test:ci