### PR TITLE
Add atomic SQLite bootstrap, first-launch metadata, and startup hook

### DIFF
--- a/__tests__/local-data-bootstrap-test.ts
+++ b/__tests__/local-data-bootstrap-test.ts
@@ -1,0 +1,87 @@
+import { bootstrapLocalData, SCHEMA_VERSION, type LocalDatabaseAdapter } from '@/lib/local-data/bootstrap';
+
+type MetaRecord = {
+  value: string;
+  updatedAt: string;
+};
+
+class FakeDatabaseAdapter implements LocalDatabaseAdapter {
+  private readonly appMeta = new Map<string, MetaRecord>();
+  private readonly migrations = new Set<number>();
+
+  async execAsync(_sql: string): Promise<void> {
+    // No-op for BEGIN / COMMIT / ROLLBACK in fake adapter.
+  }
+
+  async runAsync(sql: string, ...params: (string | number | null)[]): Promise<unknown> {
+    if (sql.includes('schema_migrations')) {
+      const version = Number(params[0]);
+      this.migrations.add(version);
+      return;
+    }
+
+    if (sql.includes('INSERT OR IGNORE INTO app_meta')) {
+      const [key, value, updatedAt] = params as [string, string, string];
+      if (!this.appMeta.has(key)) {
+        this.appMeta.set(key, { value, updatedAt });
+      }
+      return;
+    }
+
+    if (sql.includes('INSERT OR REPLACE INTO app_meta')) {
+      const [key, value, updatedAt] = params as [string, string, string];
+      this.appMeta.set(key, { value, updatedAt });
+    }
+  }
+
+  async getFirstAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T | null> {
+    if (sql.includes('FROM app_meta')) {
+      const key = String(params[0]);
+      const record = this.appMeta.get(key);
+
+      if (!record) {
+        return null;
+      }
+
+      return { value: record.value } as T;
+    }
+
+    return null;
+  }
+
+  hasMigration(version: number): boolean {
+    return this.migrations.has(version);
+  }
+
+  getMeta(key: string): MetaRecord | undefined {
+    return this.appMeta.get(key);
+  }
+}
+
+describe('bootstrapLocalData', () => {
+  it('bootstraps schema and baseline records for untouched installs', async () => {
+    const adapter = new FakeDatabaseAdapter();
+
+    const result = await bootstrapLocalData(adapter);
+
+    expect(result.wasUntouchedInstall).toBe(true);
+    expect(result.schemaVersion).toBe(SCHEMA_VERSION);
+    expect(adapter.hasMigration(SCHEMA_VERSION)).toBe(true);
+    expect(adapter.getMeta('initializedAt')).toBeDefined();
+    expect(adapter.getMeta('lastBootstrapAt')).toBeDefined();
+    expect(adapter.getMeta('schemaVersion')?.value).toBe(String(SCHEMA_VERSION));
+  });
+
+  it('keeps initializedAt stable while refreshing bootstrap metadata', async () => {
+    const adapter = new FakeDatabaseAdapter();
+
+    const firstRun = await bootstrapLocalData(adapter);
+    const secondRun = await bootstrapLocalData(adapter);
+
+    expect(secondRun.wasUntouchedInstall).toBe(false);
+    expect(secondRun.initializedAt).toBe(firstRun.initializedAt);
+    expect(new Date(secondRun.lastBootstrapAt).getTime()).toBeGreaterThanOrEqual(
+      new Date(firstRun.lastBootstrapAt).getTime()
+    );
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,8 +3,10 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { HeroUINativeProvider } from 'heroui-native';
 import 'react-native-reanimated';
+import { Text } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
+import { useAppBootstrap } from '@/hooks/use-app-bootstrap';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import '@/global.css';
 
@@ -14,6 +16,15 @@ export const unstable_settings = {
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+  const { bootstrapError, isBootstrapping } = useAppBootstrap();
+
+  if (isBootstrapping) {
+    return null;
+  }
+
+  if (bootstrapError) {
+    return <Text>Failed to initialize local data.</Text>;
+  }
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>

--- a/expo-sqlite.d.ts
+++ b/expo-sqlite.d.ts
@@ -1,0 +1,9 @@
+declare module 'expo-sqlite' {
+  export type SQLiteDatabase = {
+    execAsync(sql: string): Promise<void>;
+    runAsync(sql: string, ...params: (string | number | null)[]): Promise<unknown>;
+    getFirstAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T | null>;
+  };
+
+  export function openDatabaseAsync(name: string): Promise<SQLiteDatabase>;
+}

--- a/hooks/use-app-bootstrap.ts
+++ b/hooks/use-app-bootstrap.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+
+import { bootstrapSQLite } from '@/lib/local-data/sqlite';
+import type { BootstrapResult } from '@/lib/local-data/bootstrap';
+
+type AppBootstrapState = {
+  bootstrapResult: BootstrapResult | null;
+  bootstrapError: Error | null;
+  isBootstrapping: boolean;
+};
+
+export function useAppBootstrap(): AppBootstrapState {
+  const [bootstrapResult, setBootstrapResult] = useState<BootstrapResult | null>(null);
+  const [bootstrapError, setBootstrapError] = useState<Error | null>(null);
+  const [isBootstrapping, setIsBootstrapping] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function runBootstrap() {
+      try {
+        const result = await bootstrapSQLite();
+
+        if (isMounted) {
+          setBootstrapResult(result);
+        }
+      } catch (error) {
+        if (isMounted) {
+          setBootstrapError(error instanceof Error ? error : new Error(String(error)));
+        }
+      } finally {
+        if (isMounted) {
+          setIsBootstrapping(false);
+        }
+      }
+    }
+
+    runBootstrap();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return { bootstrapResult, bootstrapError, isBootstrapping };
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,3 @@
 export * from './scoring';
+export * from './local-data/bootstrap';
+

--- a/lib/local-data/bootstrap.ts
+++ b/lib/local-data/bootstrap.ts
@@ -1,0 +1,99 @@
+export const SCHEMA_VERSION = 1;
+
+export type BootstrapResult = {
+  initializedAt: string;
+  lastBootstrapAt: string;
+  schemaVersion: number;
+  wasUntouchedInstall: boolean;
+};
+
+type MetaRow = {
+  value: string;
+};
+
+export interface LocalDatabaseAdapter {
+  execAsync(sql: string): Promise<void>;
+  runAsync(sql: string, ...params: (string | number | null)[]): Promise<unknown>;
+  getFirstAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T | null>;
+}
+
+const createTableStatements = [
+  `CREATE TABLE IF NOT EXISTS schema_migrations (
+    version INTEGER PRIMARY KEY NOT NULL,
+    applied_at TEXT NOT NULL
+  );`,
+  `CREATE TABLE IF NOT EXISTS app_meta (
+    key TEXT PRIMARY KEY NOT NULL,
+    value TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  );`,
+];
+
+export async function bootstrapLocalData(adapter: LocalDatabaseAdapter): Promise<BootstrapResult> {
+  const nowIso = new Date().toISOString();
+
+  await adapter.execAsync('BEGIN IMMEDIATE;');
+
+  try {
+    for (const statement of createTableStatements) {
+      await adapter.execAsync(statement);
+    }
+
+    const existingInitialization = await adapter.getFirstAsync<MetaRow>(
+      'SELECT value FROM app_meta WHERE key = ? LIMIT 1;',
+      'initializedAt'
+    );
+
+    await adapter.runAsync(
+      'INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?);',
+      SCHEMA_VERSION,
+      nowIso
+    );
+
+    await adapter.runAsync(
+      'INSERT OR IGNORE INTO app_meta (key, value, updated_at) VALUES (?, ?, ?);',
+      'initializedAt',
+      nowIso,
+      nowIso
+    );
+
+    await adapter.runAsync(
+      'INSERT OR REPLACE INTO app_meta (key, value, updated_at) VALUES (?, ?, ?);',
+      'lastBootstrapAt',
+      nowIso,
+      nowIso
+    );
+
+    await adapter.runAsync(
+      'INSERT OR REPLACE INTO app_meta (key, value, updated_at) VALUES (?, ?, ?);',
+      'schemaVersion',
+      String(SCHEMA_VERSION),
+      nowIso
+    );
+
+    await adapter.execAsync('COMMIT;');
+
+    const initializedAtRow = await adapter.getFirstAsync<MetaRow>(
+      'SELECT value FROM app_meta WHERE key = ? LIMIT 1;',
+      'initializedAt'
+    );
+    const lastBootstrapAtRow = await adapter.getFirstAsync<MetaRow>(
+      'SELECT value FROM app_meta WHERE key = ? LIMIT 1;',
+      'lastBootstrapAt'
+    );
+    const schemaVersionRow = await adapter.getFirstAsync<MetaRow>(
+      'SELECT value FROM app_meta WHERE key = ? LIMIT 1;',
+      'schemaVersion'
+    );
+
+    return {
+      initializedAt: initializedAtRow?.value ?? nowIso,
+      lastBootstrapAt: lastBootstrapAtRow?.value ?? nowIso,
+      schemaVersion: Number(schemaVersionRow?.value ?? SCHEMA_VERSION),
+      wasUntouchedInstall: existingInitialization == null,
+    };
+  } catch (error) {
+    await adapter.execAsync('ROLLBACK;');
+    throw error;
+  }
+}

--- a/lib/local-data/sqlite.ts
+++ b/lib/local-data/sqlite.ts
@@ -1,0 +1,25 @@
+import { openDatabaseAsync, type SQLiteDatabase } from 'expo-sqlite';
+
+import { bootstrapLocalData, type BootstrapResult, type LocalDatabaseAdapter } from '@/lib/local-data/bootstrap';
+
+class ExpoSQLiteAdapter implements LocalDatabaseAdapter {
+  constructor(private readonly db: SQLiteDatabase) {}
+
+  execAsync(sql: string): Promise<void> {
+    return this.db.execAsync(sql);
+  }
+
+  runAsync(sql: string, ...params: (string | number | null)[]): Promise<unknown> {
+    return this.db.runAsync(sql, ...params);
+  }
+
+  getFirstAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T | null> {
+    return this.db.getFirstAsync<T>(sql, ...params);
+  }
+}
+
+export async function bootstrapSQLite(dbName = 'swipe-check.db'): Promise<BootstrapResult> {
+  const db = await openDatabaseAsync(dbName);
+  const adapter = new ExpoSQLiteAdapter(db);
+  return bootstrapLocalData(adapter);
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "expo-image": "~55.0.6",
     "expo-linking": "~55.0.9",
     "expo-router": "~55.0.8",
+    "expo-sqlite": "~16.0.8",
     "expo-splash-screen": "~55.0.13",
     "expo-status-bar": "~55.0.4",
     "expo-symbols": "~55.0.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "expo-image": "~55.0.6",
     "expo-linking": "~55.0.9",
     "expo-router": "~55.0.8",
-    "expo-sqlite": "~16.0.8",
+    "expo-sqlite": "~55.0.11",
     "expo-splash-screen": "~55.0.13",
     "expo-status-bar": "~55.0.4",
     "expo-symbols": "~55.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       expo-splash-screen:
         specifier: ~55.0.13
         version: 55.0.13(expo@55.0.9)(typescript@5.9.3)
+      expo-sqlite:
+        specifier: ~55.0.11
+        version: 55.0.11(expo@55.0.9)(react-native@0.84.1(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       expo-status-bar:
         specifier: ~55.0.4
         version: 55.0.4(react-native@0.84.1(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
@@ -1877,6 +1880,9 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  await-lock@2.2.2:
+    resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
+
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2684,6 +2690,13 @@ packages:
     resolution: {integrity: sha512-dEainzjUZbqdmcQjO7tIqoh432jloxOGzHJHErGIMxg1QlahKj0e5D/4CY1Xd6qIOs1rRBlG63mPxx7iGBWbHQ==}
     peerDependencies:
       expo: '*'
+
+  expo-sqlite@55.0.11:
+    resolution: {integrity: sha512-lDGJrE0m1lw/3y1ZSsER2kfXnS+9WzgaKcIFp/RKbTfyhs0v8l86Ulqdr+6peRFOfzi0kdj4Ty0LzE2Adx93tg==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-status-bar@55.0.4:
     resolution: {integrity: sha512-BPDjUXKqv1F9j2YNGLRZfkBEZXIEEpqj+t81y4c+4fdSN3Pos7goIHXgcl2ozbKQLgKRZQyNZQtbUgh5UjHYUQ==}
@@ -6823,7 +6836,9 @@ snapshots:
       metro-runtime: 0.83.5
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -7386,6 +7401,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  await-lock@2.2.2: {}
 
   babel-jest@29.7.0(@babel/core@7.29.0):
     dependencies:
@@ -8406,6 +8423,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  expo-sqlite@55.0.11(expo@55.0.9)(react-native@0.84.1(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4):
+    dependencies:
+      await-lock: 2.2.2
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.7)(expo-router@55.0.8)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      react: 19.2.4
+      react-native: 0.84.1(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4)
 
   expo-status-bar@55.0.4(react-native@0.84.1(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4):
     dependencies:


### PR DESCRIPTION
### Motivation
- Provide a stable, idempotent local-data foundation (schema + baseline records) so the app can reliably detect first-launch and avoid partial or duplicated setup.
- Run bootstrap during app startup and surface fatal initialization failures early to prevent the app from rendering on a partially-initialized data layer.
- Keep the bootstrap logic testable and adapter-driven so it can be exercised without a real SQLite runtime.

### Description
- Add an atomic bootstrap routine in `lib/local-data/bootstrap.ts` that creates `schema_migrations` and `app_meta`, writes `initializedAt`/`lastBootstrapAt`/`schemaVersion`, and uses `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` to avoid partial state, returning `wasUntouchedInstall` and a `BootstrapResult`.
- Add an Expo SQLite adapter and entrypoint in `lib/local-data/sqlite.ts` with `bootstrapSQLite(dbName)` that calls the bootstrap routine via an adapter implementing `LocalDatabaseAdapter`.
- Add a startup hook `hooks/use-app-bootstrap.ts` and wire it into `app/_layout.tsx` so bootstrapping runs on launch and blocks rendering until initialization completes (showing a simple error text on failure).
- Add unit tests `__tests__/local-data-bootstrap-test.ts` that exercise first-run initialization and idempotent re-runs using a `FakeDatabaseAdapter`, export the bootstrap API from `lib/index.ts`, and add a local TS declaration `expo-sqlite.d.ts` to satisfy strict typechecking in this environment.

### Testing
- Ran `pnpm typecheck` which completed successfully.
- Ran `pnpm test:ci -- __tests__/local-data-bootstrap-test.ts` and the file-specific tests passed (2 tests).
- Ran full test suite with `pnpm test:ci` and all test suites passed (6 suites, 55 tests passed).
- Ran `pnpm lint` (via `expo lint`) which completed with non-fatal npm warnings and exited successfully, and an attempted `pnpm add expo-sqlite@~16.0.8` failed due to a registry 403 (network/registry auth restriction) but a local `expo-sqlite.d.ts` file was added so the code compiles for typechecking.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc108b1a548320839b57a9ca44ce44)