### PR TITLE
Follow-up: seed and read offline question catalog deterministically

### DIFF
--- a/__tests__/local-data-bootstrap-test.ts
+++ b/__tests__/local-data-bootstrap-test.ts
@@ -1,13 +1,31 @@
-import { bootstrapLocalData, SCHEMA_VERSION, type LocalDatabaseAdapter } from '@/lib/local-data/bootstrap';
+import { QUESTIONS } from '@/constants/questions';
+import {
+  bootstrapLocalData,
+  readQuestionCatalog,
+  SCHEMA_VERSION,
+  type LocalDatabaseAdapter,
+} from '@/lib/local-data/bootstrap';
 
 type MetaRecord = {
   value: string;
   updatedAt: string;
 };
 
+type QuestionRecord = {
+  id: string;
+  prompt: string;
+  axisId: string;
+  agreePoleId: string;
+  pool: string;
+  isActive: number;
+  metadataJson: string | null;
+  sortIndex: number;
+};
+
 class FakeDatabaseAdapter implements LocalDatabaseAdapter {
   private readonly appMeta = new Map<string, MetaRecord>();
   private readonly migrations = new Set<number>();
+  private readonly questionCatalog = new Map<string, QuestionRecord>();
 
   async execAsync(_sql: string): Promise<void> {
     // No-op for BEGIN / COMMIT / ROLLBACK in fake adapter.
@@ -17,6 +35,33 @@ class FakeDatabaseAdapter implements LocalDatabaseAdapter {
     if (sql.includes('schema_migrations')) {
       const version = Number(params[0]);
       this.migrations.add(version);
+      return;
+    }
+
+    if (sql.includes('INSERT OR IGNORE INTO question_catalog')) {
+      const [id, prompt, axisId, agreePoleId, pool, isActive, metadataJson, sortIndex] = params as [
+        string,
+        string,
+        string,
+        string,
+        string,
+        number,
+        string | null,
+        number,
+      ];
+
+      if (!this.questionCatalog.has(id)) {
+        this.questionCatalog.set(id, {
+          id,
+          prompt,
+          axisId,
+          agreePoleId,
+          pool,
+          isActive,
+          metadataJson,
+          sortIndex,
+        });
+      }
       return;
     }
 
@@ -49,6 +94,25 @@ class FakeDatabaseAdapter implements LocalDatabaseAdapter {
     return null;
   }
 
+  async getAllAsync<T>(sql: string): Promise<T[]> {
+    if (sql.includes('FROM question_catalog')) {
+      return [...this.questionCatalog.values()]
+        .sort((a, b) => a.sortIndex - b.sortIndex || a.id.localeCompare(b.id))
+        .map((record) => ({
+          id: record.id,
+          prompt: record.prompt,
+          axis_id: record.axisId,
+          agree_pole_id: record.agreePoleId,
+          pool: record.pool,
+          is_active: record.isActive,
+          metadata_json: record.metadataJson,
+          sort_index: record.sortIndex,
+        })) as T[];
+    }
+
+    return [];
+  }
+
   hasMigration(version: number): boolean {
     return this.migrations.has(version);
   }
@@ -66,6 +130,7 @@ describe('bootstrapLocalData', () => {
 
     expect(result.wasUntouchedInstall).toBe(true);
     expect(result.schemaVersion).toBe(SCHEMA_VERSION);
+    expect(result.catalogQuestionCount).toBe(QUESTIONS.length);
     expect(adapter.hasMigration(SCHEMA_VERSION)).toBe(true);
     expect(adapter.getMeta('initializedAt')).toBeDefined();
     expect(adapter.getMeta('lastBootstrapAt')).toBeDefined();
@@ -79,9 +144,25 @@ describe('bootstrapLocalData', () => {
     const secondRun = await bootstrapLocalData(adapter);
 
     expect(secondRun.wasUntouchedInstall).toBe(false);
+    expect(secondRun.catalogQuestionCount).toBe(QUESTIONS.length);
     expect(secondRun.initializedAt).toBe(firstRun.initializedAt);
     expect(new Date(secondRun.lastBootstrapAt).getTime()).toBeGreaterThanOrEqual(
       new Date(firstRun.lastBootstrapAt).getTime()
     );
+  });
+
+  it('reads question catalog with the same stable order after restart', async () => {
+    const adapter = new FakeDatabaseAdapter();
+
+    await bootstrapLocalData(adapter);
+    const firstCatalogRead = await readQuestionCatalog(adapter);
+
+    await bootstrapLocalData(adapter);
+    const secondCatalogRead = await readQuestionCatalog(adapter);
+
+    expect(firstCatalogRead.map((question) => question.id)).toEqual(
+      QUESTIONS.map((question) => question.id)
+    );
+    expect(secondCatalogRead).toEqual(firstCatalogRead);
   });
 });

--- a/expo-sqlite.d.ts
+++ b/expo-sqlite.d.ts
@@ -3,6 +3,7 @@ declare module 'expo-sqlite' {
     execAsync(sql: string): Promise<void>;
     runAsync(sql: string, ...params: (string | number | null)[]): Promise<unknown>;
     getFirstAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T | null>;
+    getAllAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T[]>;
   };
 
   export function openDatabaseAsync(name: string): Promise<SQLiteDatabase>;

--- a/lib/local-data/bootstrap.ts
+++ b/lib/local-data/bootstrap.ts
@@ -1,3 +1,6 @@
+import { QUESTIONS } from '@/constants/questions';
+import type { Question, QuestionPool } from '@/constants/question-contract';
+
 export const SCHEMA_VERSION = 1;
 
 export type BootstrapResult = {
@@ -5,16 +8,29 @@ export type BootstrapResult = {
   lastBootstrapAt: string;
   schemaVersion: number;
   wasUntouchedInstall: boolean;
+  catalogQuestionCount: number;
 };
 
 type MetaRow = {
   value: string;
 };
 
+type QuestionRow = {
+  id: string;
+  prompt: string;
+  axis_id: string;
+  agree_pole_id: string;
+  pool: QuestionPool;
+  is_active: number;
+  metadata_json: string | null;
+  sort_index: number;
+};
+
 export interface LocalDatabaseAdapter {
   execAsync(sql: string): Promise<void>;
   runAsync(sql: string, ...params: (string | number | null)[]): Promise<unknown>;
   getFirstAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T | null>;
+  getAllAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T[]>;
 }
 
 const createTableStatements = [
@@ -27,7 +43,77 @@ const createTableStatements = [
     value TEXT NOT NULL,
     updated_at TEXT NOT NULL
   );`,
+  `CREATE TABLE IF NOT EXISTS question_catalog (
+    id TEXT PRIMARY KEY NOT NULL,
+    prompt TEXT NOT NULL,
+    axis_id TEXT NOT NULL,
+    agree_pole_id TEXT NOT NULL,
+    pool TEXT NOT NULL,
+    is_active INTEGER NOT NULL,
+    metadata_json TEXT,
+    sort_index INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  );`,
 ];
+
+function serializeMetadata(question: Question): string | null {
+  if (!question.metadata) {
+    return null;
+  }
+
+  return JSON.stringify({
+    ...question.metadata,
+    createdAt: question.metadata.createdAt?.toISOString(),
+    updatedAt: question.metadata.updatedAt?.toISOString(),
+  });
+}
+
+async function seedQuestionCatalog(adapter: LocalDatabaseAdapter, nowIso: string): Promise<void> {
+  for (const [sortIndex, question] of QUESTIONS.entries()) {
+    await adapter.runAsync(
+      `INSERT OR IGNORE INTO question_catalog
+       (id, prompt, axis_id, agree_pole_id, pool, is_active, metadata_json, sort_index, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`,
+      question.id,
+      question.prompt,
+      question.axisId,
+      question.agreePoleId,
+      question.pool,
+      question.isActive ? 1 : 0,
+      serializeMetadata(question),
+      sortIndex,
+      nowIso,
+      nowIso
+    );
+  }
+}
+
+export async function readQuestionCatalog(adapter: LocalDatabaseAdapter): Promise<Question[]> {
+  const rows = await adapter.getAllAsync<QuestionRow>(
+    'SELECT id, prompt, axis_id, agree_pole_id, pool, is_active, metadata_json, sort_index FROM question_catalog ORDER BY sort_index ASC, id ASC;'
+  );
+
+  return rows.map((row) => {
+    const metadata = row.metadata_json ? JSON.parse(row.metadata_json) : undefined;
+
+    return {
+      id: row.id,
+      prompt: row.prompt,
+      axisId: row.axis_id,
+      agreePoleId: row.agree_pole_id,
+      pool: row.pool,
+      isActive: row.is_active === 1,
+      metadata: metadata
+        ? {
+            ...metadata,
+            createdAt: metadata.createdAt ? new Date(metadata.createdAt) : undefined,
+            updatedAt: metadata.updatedAt ? new Date(metadata.updatedAt) : undefined,
+          }
+        : undefined,
+    } satisfies Question;
+  });
+}
 
 export async function bootstrapLocalData(adapter: LocalDatabaseAdapter): Promise<BootstrapResult> {
   const nowIso = new Date().toISOString();
@@ -49,6 +135,8 @@ export async function bootstrapLocalData(adapter: LocalDatabaseAdapter): Promise
       SCHEMA_VERSION,
       nowIso
     );
+
+    await seedQuestionCatalog(adapter, nowIso);
 
     await adapter.runAsync(
       'INSERT OR IGNORE INTO app_meta (key, value, updated_at) VALUES (?, ?, ?);',
@@ -86,11 +174,14 @@ export async function bootstrapLocalData(adapter: LocalDatabaseAdapter): Promise
       'schemaVersion'
     );
 
+    const catalog = await readQuestionCatalog(adapter);
+
     return {
       initializedAt: initializedAtRow?.value ?? nowIso,
       lastBootstrapAt: lastBootstrapAtRow?.value ?? nowIso,
       schemaVersion: Number(schemaVersionRow?.value ?? SCHEMA_VERSION),
       wasUntouchedInstall: existingInitialization == null,
+      catalogQuestionCount: catalog.length,
     };
   } catch (error) {
     await adapter.execAsync('ROLLBACK;');

--- a/lib/local-data/sqlite.ts
+++ b/lib/local-data/sqlite.ts
@@ -1,6 +1,12 @@
 import { openDatabaseAsync, type SQLiteDatabase } from 'expo-sqlite';
 
-import { bootstrapLocalData, type BootstrapResult, type LocalDatabaseAdapter } from '@/lib/local-data/bootstrap';
+import {
+  bootstrapLocalData,
+  readQuestionCatalog,
+  type BootstrapResult,
+  type LocalDatabaseAdapter,
+} from '@/lib/local-data/bootstrap';
+import type { Question } from '@/constants/question-contract';
 
 class ExpoSQLiteAdapter implements LocalDatabaseAdapter {
   constructor(private readonly db: SQLiteDatabase) {}
@@ -16,10 +22,23 @@ class ExpoSQLiteAdapter implements LocalDatabaseAdapter {
   getFirstAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T | null> {
     return this.db.getFirstAsync<T>(sql, ...params);
   }
+
+  getAllAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T[]> {
+    return this.db.getAllAsync<T>(sql, ...params);
+  }
+}
+
+async function openAdapter(dbName: string): Promise<ExpoSQLiteAdapter> {
+  const db = await openDatabaseAsync(dbName);
+  return new ExpoSQLiteAdapter(db);
 }
 
 export async function bootstrapSQLite(dbName = 'swipe-check.db'): Promise<BootstrapResult> {
-  const db = await openDatabaseAsync(dbName);
-  const adapter = new ExpoSQLiteAdapter(db);
+  const adapter = await openAdapter(dbName);
   return bootstrapLocalData(adapter);
+}
+
+export async function getStoredQuestionsSQLite(dbName = 'swipe-check.db'): Promise<Question[]> {
+  const adapter = await openAdapter(dbName);
+  return readQuestionCatalog(adapter);
 }


### PR DESCRIPTION
### Motivation
- Ensure the app has a durable, deterministic offline question catalog on first launch as required by Epic 02.2.  
- Make seeding idempotent and reads stable across restarts so downstream features can rely on the persisted catalog.  

### Description
- Create a `question_catalog` table and seed it from the canonical `QUESTIONS` using `INSERT OR IGNORE` so seeding is idempotent and avoids duplicate rows.  
- Add a stable `sort_index` when seeding and implement `readQuestionCatalog` to return rows ordered by `sort_index, id` for deterministic reads.  
- Expose catalog helpers via `bootstrapLocalData` (now returns `catalogQuestionCount`) and add `getStoredQuestionsSQLite` plus an Expo SQLite adapter method `getAllAsync`.  
- Add test adapter and update bootstrap tests to verify first-run seed, idempotent re-bootstrap, and deterministic ordering, and update the local `expo-sqlite` type shim to include `getAllAsync`.  

### Testing
- Ran `pnpm typecheck` and it passed after adding `getAllAsync` to the local `expo-sqlite` typings.  
- Ran `pnpm test:ci` and all test suites passed (`56` tests passed).  
- Ran `pnpm lint` (via `expo lint`) with only non-blocking environment warnings and no lint failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1761fcb88320bf55593003675f77)