### PR TITLE
Persist onboarding & daily session lifecycle; enforce one daily session per local day

### DIFF
--- a/__tests__/session-lifecycle-test.ts
+++ b/__tests__/session-lifecycle-test.ts
@@ -1,0 +1,249 @@
+import type { QuestionResponse } from '@/constants/question-contract';
+import {
+  completeSession,
+  getOrCreateDailySessionForLocalDay,
+  readSessionAnswers,
+  startOrResumeOnboardingSession,
+  toLocalDayKey,
+  upsertSessionAnswer,
+} from '@/lib/local-data/session-lifecycle';
+import type { LocalDatabaseAdapter } from '@/lib/local-data/bootstrap';
+
+type SessionRecord = {
+  id: string;
+  type: 'onboarding' | 'daily';
+  status: 'in_progress' | 'completed';
+  localDayKey: string | null;
+  startedAt: string;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type SessionAnswerRecord = {
+  sessionId: string;
+  questionId: string;
+  answer: QuestionResponse;
+  answeredAt: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+class FakeSessionAdapter implements LocalDatabaseAdapter {
+  private readonly sessions = new Map<string, SessionRecord>();
+  private readonly answers = new Map<string, SessionAnswerRecord>();
+
+  async execAsync(_sql: string): Promise<void> {
+    // no-op for tests
+  }
+
+  async runAsync(sql: string, ...params: (string | number | null)[]): Promise<unknown> {
+    if (sql.includes("INSERT INTO sessions") && sql.includes("'onboarding'")) {
+      const [id, startedAt, createdAt, updatedAt] = params as [string, string, string, string];
+      this.sessions.set(id, {
+        id,
+        type: 'onboarding',
+        status: 'in_progress',
+        localDayKey: null,
+        startedAt,
+        completedAt: null,
+        createdAt,
+        updatedAt,
+      });
+      return;
+    }
+
+    if (sql.includes("INSERT INTO sessions") && sql.includes("'daily'")) {
+      const [id, localDayKey, startedAt, createdAt, updatedAt] = params as [
+        string,
+        string,
+        string,
+        string,
+        string,
+      ];
+
+      for (const session of this.sessions.values()) {
+        if (session.type === 'daily' && session.localDayKey === localDayKey) {
+          throw new Error('UNIQUE constraint failed: sessions.session_type, sessions.local_day_key');
+        }
+      }
+
+      this.sessions.set(id, {
+        id,
+        type: 'daily',
+        status: 'in_progress',
+        localDayKey,
+        startedAt,
+        completedAt: null,
+        createdAt,
+        updatedAt,
+      });
+      return;
+    }
+
+    if (sql.includes('INSERT INTO session_answers')) {
+      const [sessionId, questionId, answer, answeredAt, createdAt, updatedAt] = params as [
+        string,
+        string,
+        QuestionResponse,
+        string,
+        string,
+        string,
+      ];
+
+      this.answers.set(`${sessionId}::${questionId}`, {
+        sessionId,
+        questionId,
+        answer,
+        answeredAt,
+        createdAt,
+        updatedAt,
+      });
+      return;
+    }
+
+    if (sql.includes('UPDATE sessions')) {
+      const [completedAt, updatedAt, sessionId] = params as [string, string, string];
+      const session = this.sessions.get(sessionId);
+      if (!session) {
+        return;
+      }
+
+      this.sessions.set(sessionId, {
+        ...session,
+        status: 'completed',
+        completedAt,
+        updatedAt,
+      });
+    }
+  }
+
+  async getFirstAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T | null> {
+    if (sql.includes("session_type = 'onboarding'") && sql.includes("status = 'in_progress'")) {
+      const onboardingSession = [...this.sessions.values()]
+        .filter((session) => session.type === 'onboarding' && session.status === 'in_progress')
+        .sort((a, b) => b.startedAt.localeCompare(a.startedAt))[0];
+
+      if (!onboardingSession) {
+        return null;
+      }
+
+      return {
+        id: onboardingSession.id,
+        session_type: onboardingSession.type,
+        status: onboardingSession.status,
+        local_day_key: onboardingSession.localDayKey,
+        started_at: onboardingSession.startedAt,
+        completed_at: onboardingSession.completedAt,
+        created_at: onboardingSession.createdAt,
+        updated_at: onboardingSession.updatedAt,
+      } as T;
+    }
+
+    if (sql.includes("session_type = 'daily'")) {
+      const [localDayKey] = params as [string];
+      const dailySession = [...this.sessions.values()]
+        .filter((session) => session.type === 'daily' && session.localDayKey === localDayKey)
+        .sort((a, b) => b.startedAt.localeCompare(a.startedAt))[0];
+
+      if (!dailySession) {
+        return null;
+      }
+
+      return {
+        id: dailySession.id,
+        session_type: dailySession.type,
+        status: dailySession.status,
+        local_day_key: dailySession.localDayKey,
+        started_at: dailySession.startedAt,
+        completed_at: dailySession.completedAt,
+        created_at: dailySession.createdAt,
+        updated_at: dailySession.updatedAt,
+      } as T;
+    }
+
+    return null;
+  }
+
+  async getAllAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T[]> {
+    if (sql.includes('FROM session_answers')) {
+      const [sessionId] = params as [string];
+
+      return [...this.answers.values()]
+        .filter((answer) => answer.sessionId === sessionId)
+        .sort((a, b) => a.answeredAt.localeCompare(b.answeredAt) || a.questionId.localeCompare(b.questionId))
+        .map((answer) => ({
+          session_id: answer.sessionId,
+          question_id: answer.questionId,
+          answer: answer.answer,
+          answered_at: answer.answeredAt,
+        })) as T[];
+    }
+
+    return [];
+  }
+}
+
+describe('session lifecycle persistence helpers', () => {
+  it('starts onboarding once and resumes same in-progress session across restarts', async () => {
+    const adapter = new FakeSessionAdapter();
+
+    const first = await startOrResumeOnboardingSession(adapter, new Date('2026-01-01T08:00:00.000Z'));
+    const second = await startOrResumeOnboardingSession(adapter, new Date('2026-01-01T09:00:00.000Z'));
+
+    expect(second.id).toBe(first.id);
+    expect(second.status).toBe('in_progress');
+  });
+
+  it('persists and updates answers for a session without duplicating question entries', async () => {
+    const adapter = new FakeSessionAdapter();
+    const session = await startOrResumeOnboardingSession(adapter, new Date('2026-01-01T08:00:00.000Z'));
+
+    await upsertSessionAnswer(adapter, session.id, 'q-001', 'agree', new Date('2026-01-01T08:01:00.000Z'));
+    await upsertSessionAnswer(adapter, session.id, 'q-001', 'disagree', new Date('2026-01-01T08:02:00.000Z'));
+    await upsertSessionAnswer(adapter, session.id, 'q-002', 'agree', new Date('2026-01-01T08:03:00.000Z'));
+
+    const answers = await readSessionAnswers(adapter, session.id);
+
+    expect(answers).toEqual([
+      {
+        sessionId: session.id,
+        questionId: 'q-001',
+        answer: 'disagree',
+        answeredAt: '2026-01-01T08:02:00.000Z',
+      },
+      {
+        sessionId: session.id,
+        questionId: 'q-002',
+        answer: 'agree',
+        answeredAt: '2026-01-01T08:03:00.000Z',
+      },
+    ]);
+  });
+
+  it('enforces one daily session per local calendar day and reuses completed session', async () => {
+    const adapter = new FakeSessionAdapter();
+    const localDayKey = '2026-01-01';
+
+    const first = await getOrCreateDailySessionForLocalDay(
+      adapter,
+      localDayKey,
+      new Date('2026-01-01T08:00:00.000Z')
+    );
+
+    await completeSession(adapter, first.id, new Date('2026-01-01T08:10:00.000Z'));
+
+    const reopened = await getOrCreateDailySessionForLocalDay(
+      adapter,
+      localDayKey,
+      new Date('2026-01-01T11:00:00.000Z')
+    );
+
+    expect(reopened.id).toBe(first.id);
+    expect(reopened.status).toBe('completed');
+  });
+
+  it('generates local day keys using device-local calendar boundaries', () => {
+    expect(toLocalDayKey(new Date('2026-01-01T23:59:59.999Z'))).toMatch(/^2026-\d{2}-\d{2}$/);
+  });
+});

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './scoring';
 export * from './local-data/bootstrap';
 
+export * from './local-data/session-lifecycle';

--- a/lib/local-data/bootstrap.ts
+++ b/lib/local-data/bootstrap.ts
@@ -1,7 +1,7 @@
 import { QUESTIONS } from '@/constants/questions';
 import type { Question, QuestionPool } from '@/constants/question-contract';
 
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export type BootstrapResult = {
   initializedAt: string;
@@ -54,6 +54,37 @@ const createTableStatements = [
     sort_index INTEGER NOT NULL,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
+  );`,
+
+  `CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY NOT NULL,
+    session_type TEXT NOT NULL,
+    status TEXT NOT NULL,
+    local_day_key TEXT,
+    started_at TEXT NOT NULL,
+    completed_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    CHECK (session_type IN ('onboarding', 'daily')),
+    CHECK (status IN ('in_progress', 'completed')),
+    CHECK (
+      (session_type = 'daily' AND local_day_key IS NOT NULL)
+      OR (session_type = 'onboarding' AND local_day_key IS NULL)
+    )
+  );`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_daily_unique_day
+   ON sessions(session_type, local_day_key);`,
+  `CREATE TABLE IF NOT EXISTS session_answers (
+    session_id TEXT NOT NULL,
+    question_id TEXT NOT NULL,
+    answer TEXT NOT NULL,
+    answered_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (session_id, question_id),
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE,
+    FOREIGN KEY (question_id) REFERENCES question_catalog(id),
+    CHECK (answer IN ('agree', 'disagree'))
   );`,
 ];
 

--- a/lib/local-data/session-lifecycle.ts
+++ b/lib/local-data/session-lifecycle.ts
@@ -1,0 +1,233 @@
+import type { QuestionResponse } from '@/constants/question-contract';
+import type { LocalDatabaseAdapter } from '@/lib/local-data/bootstrap';
+
+export type PersistedSessionType = 'onboarding' | 'daily';
+export type PersistedSessionStatus = 'in_progress' | 'completed';
+
+export type PersistedSession = {
+  id: string;
+  type: PersistedSessionType;
+  status: PersistedSessionStatus;
+  localDayKey: string | null;
+  startedAt: string;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PersistedSessionAnswer = {
+  sessionId: string;
+  questionId: string;
+  answer: QuestionResponse;
+  answeredAt: string;
+};
+
+type SessionRow = {
+  id: string;
+  session_type: PersistedSessionType;
+  status: PersistedSessionStatus;
+  local_day_key: string | null;
+  started_at: string;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type SessionAnswerRow = {
+  session_id: string;
+  question_id: string;
+  answer: QuestionResponse;
+  answered_at: string;
+};
+
+function createSessionId(): string {
+  if (typeof globalThis.crypto !== 'undefined' && typeof globalThis.crypto.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+
+  return `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function mapSessionRow(row: SessionRow): PersistedSession {
+  return {
+    id: row.id,
+    type: row.session_type,
+    status: row.status,
+    localDayKey: row.local_day_key,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function getInProgressOnboardingSession(
+  adapter: LocalDatabaseAdapter
+): Promise<PersistedSession | null> {
+  const row = await adapter.getFirstAsync<SessionRow>(
+    `SELECT id, session_type, status, local_day_key, started_at, completed_at, created_at, updated_at
+     FROM sessions
+     WHERE session_type = 'onboarding' AND status = 'in_progress'
+     ORDER BY started_at DESC
+     LIMIT 1;`
+  );
+
+  return row ? mapSessionRow(row) : null;
+}
+
+export async function startOrResumeOnboardingSession(
+  adapter: LocalDatabaseAdapter,
+  now = new Date()
+): Promise<PersistedSession> {
+  const existing = await getInProgressOnboardingSession(adapter);
+  if (existing) {
+    return existing;
+  }
+
+  const nowIso = now.toISOString();
+  const sessionId = createSessionId();
+
+  await adapter.runAsync(
+    `INSERT INTO sessions
+     (id, session_type, status, local_day_key, started_at, completed_at, created_at, updated_at)
+     VALUES (?, 'onboarding', 'in_progress', NULL, ?, NULL, ?, ?);`,
+    sessionId,
+    nowIso,
+    nowIso,
+    nowIso
+  );
+
+  return {
+    id: sessionId,
+    type: 'onboarding',
+    status: 'in_progress',
+    localDayKey: null,
+    startedAt: nowIso,
+    completedAt: null,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  };
+}
+
+export async function getDailySessionForLocalDay(
+  adapter: LocalDatabaseAdapter,
+  localDayKey: string
+): Promise<PersistedSession | null> {
+  const row = await adapter.getFirstAsync<SessionRow>(
+    `SELECT id, session_type, status, local_day_key, started_at, completed_at, created_at, updated_at
+     FROM sessions
+     WHERE session_type = 'daily' AND local_day_key = ?
+     ORDER BY started_at DESC
+     LIMIT 1;`,
+    localDayKey
+  );
+
+  return row ? mapSessionRow(row) : null;
+}
+
+export async function getOrCreateDailySessionForLocalDay(
+  adapter: LocalDatabaseAdapter,
+  localDayKey: string,
+  now = new Date()
+): Promise<PersistedSession> {
+  const existing = await getDailySessionForLocalDay(adapter, localDayKey);
+  if (existing) {
+    return existing;
+  }
+
+  const nowIso = now.toISOString();
+  const sessionId = createSessionId();
+
+  await adapter.runAsync(
+    `INSERT INTO sessions
+     (id, session_type, status, local_day_key, started_at, completed_at, created_at, updated_at)
+     VALUES (?, 'daily', 'in_progress', ?, ?, NULL, ?, ?);`,
+    sessionId,
+    localDayKey,
+    nowIso,
+    nowIso,
+    nowIso
+  );
+
+  return {
+    id: sessionId,
+    type: 'daily',
+    status: 'in_progress',
+    localDayKey,
+    startedAt: nowIso,
+    completedAt: null,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  };
+}
+
+export async function upsertSessionAnswer(
+  adapter: LocalDatabaseAdapter,
+  sessionId: string,
+  questionId: string,
+  answer: QuestionResponse,
+  answeredAt = new Date()
+): Promise<void> {
+  const answeredAtIso = answeredAt.toISOString();
+
+  await adapter.runAsync(
+    `INSERT INTO session_answers
+     (session_id, question_id, answer, answered_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(session_id, question_id) DO UPDATE SET
+       answer = excluded.answer,
+       answered_at = excluded.answered_at,
+       updated_at = excluded.updated_at;`,
+    sessionId,
+    questionId,
+    answer,
+    answeredAtIso,
+    answeredAtIso,
+    answeredAtIso
+  );
+}
+
+export async function readSessionAnswers(
+  adapter: LocalDatabaseAdapter,
+  sessionId: string
+): Promise<PersistedSessionAnswer[]> {
+  const rows = await adapter.getAllAsync<SessionAnswerRow>(
+    `SELECT session_id, question_id, answer, answered_at
+     FROM session_answers
+     WHERE session_id = ?
+     ORDER BY answered_at ASC, question_id ASC;`,
+    sessionId
+  );
+
+  return rows.map((row) => ({
+    sessionId: row.session_id,
+    questionId: row.question_id,
+    answer: row.answer,
+    answeredAt: row.answered_at,
+  }));
+}
+
+export async function completeSession(
+  adapter: LocalDatabaseAdapter,
+  sessionId: string,
+  completedAt = new Date()
+): Promise<void> {
+  const completedAtIso = completedAt.toISOString();
+
+  await adapter.runAsync(
+    `UPDATE sessions
+     SET status = 'completed', completed_at = ?, updated_at = ?
+     WHERE id = ?;`,
+    completedAtIso,
+    completedAtIso,
+    sessionId
+  );
+}
+
+export function toLocalDayKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
### Motivation
- Provide durable local persistence for onboarding and daily sessions so interrupted flows can be resumed across restarts.
- Ensure the platform enforces at most one completed daily session per device-local calendar day to prevent duplicates.
- Expose a small, testable API surface for session lifecycle operations that other parts of the app can rely on.

### Description
- Bumped `SCHEMA_VERSION` to `2` and added `sessions` and `session_answers` schema with constraints, a `CHECK` policy, and a unique index to guard daily-session uniqueness.
- Implemented `lib/local-data/session-lifecycle.ts` with helpers `startOrResumeOnboardingSession`, `getOrCreateDailySessionForLocalDay`, `getDailySessionForLocalDay`, `upsertSessionAnswer`, `readSessionAnswers`, `completeSession`, and `toLocalDayKey`.
- Exported the new lifecycle helpers from the library barrel in `lib/index.ts` for downstream usage.
- Added unit tests in `__tests__/session-lifecycle-test.ts` covering onboarding resume, answer upsert semantics, one-per-day enforcement with same-day reopen, and local day key formatting.

### Testing
- Ran the focused test suite with `pnpm -s test:ci` and the new `__tests__/session-lifecycle-test.ts`, and all tests passed (total suites passed: 7, tests: 60 passed).
- Ran lint with `pnpm -s lint`, which completed with environment warnings but no blocking failures.
- Ran type checking with `pnpm -s typecheck`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1b2071a083208b5b45e60b69e4b7)