### PR TITLE
Follow-up: persist and query durable type snapshots for sessions

### DIFF
--- a/__tests__/session-lifecycle-test.ts
+++ b/__tests__/session-lifecycle-test.ts
@@ -2,12 +2,16 @@ import type { QuestionResponse } from '@/constants/question-contract';
 import {
   completeSession,
   getOrCreateDailySessionForLocalDay,
+  readAllTypeSnapshots,
   readSessionAnswers,
+  readSessionTypeSnapshot,
   startOrResumeOnboardingSession,
   toLocalDayKey,
+  upsertTypeSnapshot,
   upsertSessionAnswer,
 } from '@/lib/local-data/session-lifecycle';
 import type { LocalDatabaseAdapter } from '@/lib/local-data/bootstrap';
+import type { TypeSnapshot } from '@/constants/scoring-contract';
 
 type SessionRecord = {
   id: string;
@@ -32,6 +36,7 @@ type SessionAnswerRecord = {
 class FakeSessionAdapter implements LocalDatabaseAdapter {
   private readonly sessions = new Map<string, SessionRecord>();
   private readonly answers = new Map<string, SessionAnswerRecord>();
+  private readonly snapshots = new Map<string, TypeSnapshot>();
 
   async execAsync(_sql: string): Promise<void> {
     // no-op for tests
@@ -115,6 +120,34 @@ class FakeSessionAdapter implements LocalDatabaseAdapter {
         completedAt,
         updatedAt,
       });
+      return;
+    }
+
+    if (sql.includes('INSERT INTO type_snapshots')) {
+      const [
+        id,
+        sessionId,
+        currentType,
+        axisScoresJson,
+        axisStrengthsJson,
+        sourceType,
+        sourceSessionId,
+        questionCount,
+        createdAt,
+      ] = params as [string, string | null, string, string, string, 'onboarding' | 'daily' | 'manual', string | null, number, string];
+
+      this.snapshots.set(id, {
+        id,
+        currentType,
+        axisScores: JSON.parse(axisScoresJson),
+        axisStrengths: JSON.parse(axisStrengthsJson),
+        createdAt: new Date(createdAt),
+        source: {
+          type: sourceType,
+          sessionId: sourceSessionId ?? undefined,
+        },
+        questionCount,
+      });
     }
   }
 
@@ -162,6 +195,29 @@ class FakeSessionAdapter implements LocalDatabaseAdapter {
       } as T;
     }
 
+    if (sql.includes('FROM type_snapshots') && sql.includes('WHERE session_id = ?')) {
+      const [sessionId] = params as [string];
+      const snapshot = [...this.snapshots.values()]
+        .filter((entry) => entry.source.sessionId === sessionId)
+        .sort((a, b) => b.createdAt.toISOString().localeCompare(a.createdAt.toISOString()))[0];
+
+      if (!snapshot) {
+        return null;
+      }
+
+      return {
+        id: snapshot.id,
+        session_id: snapshot.source.sessionId ?? null,
+        current_type: snapshot.currentType,
+        axis_scores_json: JSON.stringify(snapshot.axisScores),
+        axis_strengths_json: JSON.stringify(snapshot.axisStrengths),
+        source_type: snapshot.source.type,
+        source_session_id: snapshot.source.sessionId ?? null,
+        question_count: snapshot.questionCount,
+        created_at: snapshot.createdAt.toISOString(),
+      } as T;
+    }
+
     return null;
   }
 
@@ -177,6 +233,22 @@ class FakeSessionAdapter implements LocalDatabaseAdapter {
           question_id: answer.questionId,
           answer: answer.answer,
           answered_at: answer.answeredAt,
+        })) as T[];
+    }
+
+    if (sql.includes('FROM type_snapshots')) {
+      return [...this.snapshots.values()]
+        .sort((a, b) => a.createdAt.toISOString().localeCompare(b.createdAt.toISOString()) || a.id.localeCompare(b.id))
+        .map((snapshot) => ({
+          id: snapshot.id,
+          session_id: snapshot.source.sessionId ?? null,
+          current_type: snapshot.currentType,
+          axis_scores_json: JSON.stringify(snapshot.axisScores),
+          axis_strengths_json: JSON.stringify(snapshot.axisStrengths),
+          source_type: snapshot.source.type,
+          source_session_id: snapshot.source.sessionId ?? null,
+          question_count: snapshot.questionCount,
+          created_at: snapshot.createdAt.toISOString(),
         })) as T[];
     }
 
@@ -245,5 +317,28 @@ describe('session lifecycle persistence helpers', () => {
 
   it('generates local day keys using device-local calendar boundaries', () => {
     expect(toLocalDayKey(new Date('2026-01-01T23:59:59.999Z'))).toMatch(/^2026-\d{2}-\d{2}$/);
+  });
+
+  it('persists and reloads type snapshots for completed sessions', async () => {
+    const adapter = new FakeSessionAdapter();
+    const session = await startOrResumeOnboardingSession(adapter, new Date('2026-01-01T08:00:00.000Z'));
+
+    const snapshot: TypeSnapshot = {
+      id: 'snap-001',
+      currentType: 'INTJ',
+      axisScores: [],
+      axisStrengths: [],
+      createdAt: new Date('2026-01-01T08:04:00.000Z'),
+      source: { type: 'onboarding', sessionId: session.id },
+      questionCount: 12,
+    };
+
+    await upsertTypeSnapshot(adapter, snapshot);
+
+    const storedForSession = await readSessionTypeSnapshot(adapter, session.id);
+    const history = await readAllTypeSnapshots(adapter);
+
+    expect(storedForSession).toEqual(snapshot);
+    expect(history).toEqual([snapshot]);
   });
 });

--- a/lib/local-data/bootstrap.ts
+++ b/lib/local-data/bootstrap.ts
@@ -1,7 +1,7 @@
 import { QUESTIONS } from '@/constants/questions';
 import type { Question, QuestionPool } from '@/constants/question-contract';
 
-export const SCHEMA_VERSION = 2;
+export const SCHEMA_VERSION = 3;
 
 export type BootstrapResult = {
   initializedAt: string;
@@ -86,6 +86,25 @@ const createTableStatements = [
     FOREIGN KEY (question_id) REFERENCES question_catalog(id),
     CHECK (answer IN ('agree', 'disagree'))
   );`,
+  `CREATE TABLE IF NOT EXISTS type_snapshots (
+    id TEXT PRIMARY KEY NOT NULL,
+    session_id TEXT,
+    current_type TEXT NOT NULL,
+    axis_scores_json TEXT NOT NULL,
+    axis_strengths_json TEXT NOT NULL,
+    source_type TEXT NOT NULL,
+    source_session_id TEXT,
+    question_count INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    inserted_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE SET NULL,
+    CHECK (source_type IN ('onboarding', 'daily', 'manual'))
+  );`,
+  `CREATE INDEX IF NOT EXISTS idx_type_snapshots_created_at
+   ON type_snapshots(created_at);`,
+  `CREATE INDEX IF NOT EXISTS idx_type_snapshots_session_id
+   ON type_snapshots(session_id);`,
 ];
 
 function serializeMetadata(question: Question): string | null {

--- a/lib/local-data/session-lifecycle.ts
+++ b/lib/local-data/session-lifecycle.ts
@@ -1,4 +1,5 @@
 import type { QuestionResponse } from '@/constants/question-contract';
+import type { TypeSnapshot } from '@/constants/scoring-contract';
 import type { LocalDatabaseAdapter } from '@/lib/local-data/bootstrap';
 
 export type PersistedSessionType = 'onboarding' | 'daily';
@@ -38,6 +39,18 @@ type SessionAnswerRow = {
   question_id: string;
   answer: QuestionResponse;
   answered_at: string;
+};
+
+type TypeSnapshotRow = {
+  id: string;
+  session_id: string | null;
+  current_type: string;
+  axis_scores_json: string;
+  axis_strengths_json: string;
+  source_type: TypeSnapshot['source']['type'];
+  source_session_id: string | null;
+  question_count: number;
+  created_at: string;
 };
 
 function createSessionId(): string {
@@ -222,6 +235,83 @@ export async function completeSession(
     completedAtIso,
     sessionId
   );
+}
+
+function mapTypeSnapshotRow(row: TypeSnapshotRow): TypeSnapshot {
+  return {
+    id: row.id,
+    currentType: row.current_type,
+    axisScores: JSON.parse(row.axis_scores_json),
+    axisStrengths: JSON.parse(row.axis_strengths_json),
+    createdAt: new Date(row.created_at),
+    source: {
+      type: row.source_type,
+      sessionId: row.source_session_id ?? undefined,
+    },
+    questionCount: row.question_count,
+  };
+}
+
+export async function upsertTypeSnapshot(
+  adapter: LocalDatabaseAdapter,
+  snapshot: TypeSnapshot
+): Promise<void> {
+  const nowIso = new Date().toISOString();
+  const createdAtIso = snapshot.createdAt.toISOString();
+  const sessionId = snapshot.source.sessionId ?? null;
+
+  await adapter.runAsync(
+    `INSERT INTO type_snapshots
+     (id, session_id, current_type, axis_scores_json, axis_strengths_json, source_type, source_session_id, question_count, created_at, inserted_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+      session_id = excluded.session_id,
+      current_type = excluded.current_type,
+      axis_scores_json = excluded.axis_scores_json,
+      axis_strengths_json = excluded.axis_strengths_json,
+      source_type = excluded.source_type,
+      source_session_id = excluded.source_session_id,
+      question_count = excluded.question_count,
+      created_at = excluded.created_at,
+      updated_at = excluded.updated_at;`,
+    snapshot.id,
+    sessionId,
+    snapshot.currentType,
+    JSON.stringify(snapshot.axisScores),
+    JSON.stringify(snapshot.axisStrengths),
+    snapshot.source.type,
+    sessionId,
+    snapshot.questionCount,
+    createdAtIso,
+    nowIso,
+    nowIso
+  );
+}
+
+export async function readSessionTypeSnapshot(
+  adapter: LocalDatabaseAdapter,
+  sessionId: string
+): Promise<TypeSnapshot | null> {
+  const row = await adapter.getFirstAsync<TypeSnapshotRow>(
+    `SELECT id, session_id, current_type, axis_scores_json, axis_strengths_json, source_type, source_session_id, question_count, created_at
+     FROM type_snapshots
+     WHERE session_id = ?
+     ORDER BY created_at DESC, id DESC
+     LIMIT 1;`,
+    sessionId
+  );
+
+  return row ? mapTypeSnapshotRow(row) : null;
+}
+
+export async function readAllTypeSnapshots(adapter: LocalDatabaseAdapter): Promise<TypeSnapshot[]> {
+  const rows = await adapter.getAllAsync<TypeSnapshotRow>(
+    `SELECT id, session_id, current_type, axis_scores_json, axis_strengths_json, source_type, source_session_id, question_count, created_at
+     FROM type_snapshots
+     ORDER BY created_at ASC, id ASC;`
+  );
+
+  return rows.map(mapTypeSnapshotRow);
 }
 
 export function toLocalDayKey(date: Date): string {


### PR DESCRIPTION
closes https://github.com/hugo-hsi-dev/swipe-check/issues/36
### Motivation
- Close the gap in durable session storage by persisting computed type snapshots so completed sessions can be reconstructed and historical/current type state can be queried later. 
- Ensure journal/insights can rely on a stored timeline of computed types aligned with session answers and timestamps.

### Description
- Bumped `SCHEMA_VERSION` to `3` and added a new `type_snapshots` table plus indexes for chronological and session lookups in `lib/local-data/bootstrap.ts`.
- Implemented snapshot persistence helpers in `lib/local-data/session-lifecycle.ts`: `upsertTypeSnapshot`, `readSessionTypeSnapshot`, and `readAllTypeSnapshots`, including `TypeSnapshotRow` mapping and `mapTypeSnapshotRow` reconstruction logic.
- Extended the test harness in `__tests__/session-lifecycle-test.ts` and the fake `LocalDatabaseAdapter` to exercise snapshot insert/read behavior and added an integration-style test that writes a snapshot and verifies `readSessionTypeSnapshot` and `readAllTypeSnapshots` return the stored snapshot.

### Testing
- Ran linter with `pnpm lint` and it completed without errors.
- Ran type checking with `pnpm typecheck` and it completed without errors.
- Ran the test suite with `pnpm test:ci` and all tests passed: `61` tests across `7` suites succeeded, including the new snapshot test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1e0c04288320bcb658a9a47ff189)