### PR TITLE
Follow-up: add persisted read queries for history, insights, and onboarding state

### DIFF
--- a/__tests__/session-lifecycle-test.ts
+++ b/__tests__/session-lifecycle-test.ts
@@ -2,13 +2,18 @@ import type { QuestionResponse } from '@/constants/question-contract';
 import {
   completeSession,
   getOrCreateDailySessionForLocalDay,
+  hasCompletedOnboardingSession,
+  readActiveOrLatestDailySession,
   readAllTypeSnapshots,
+  readCompletedSessionDetail,
+  readCompletedSessionHistory,
+  readLatestTypeSnapshot,
   readSessionAnswers,
   readSessionTypeSnapshot,
   startOrResumeOnboardingSession,
   toLocalDayKey,
-  upsertTypeSnapshot,
   upsertSessionAnswer,
+  upsertTypeSnapshot,
 } from '@/lib/local-data/session-lifecycle';
 import type { LocalDatabaseAdapter } from '@/lib/local-data/bootstrap';
 import type { TypeSnapshot } from '@/constants/scoring-contract';
@@ -173,6 +178,35 @@ class FakeSessionAdapter implements LocalDatabaseAdapter {
       } as T;
     }
 
+    if (sql.includes("WHERE session_type = 'daily'") && sql.includes("CASE WHEN status = 'in_progress'")) {
+      const dailySession = [...this.sessions.values()]
+        .filter((session) => session.type === 'daily')
+        .sort((a, b) => {
+          const aRank = a.status === 'in_progress' ? 0 : 1;
+          const bRank = b.status === 'in_progress' ? 0 : 1;
+          if (aRank !== bRank) {
+            return aRank - bRank;
+          }
+
+          return b.startedAt.localeCompare(a.startedAt) || b.id.localeCompare(a.id);
+        })[0];
+
+      if (!dailySession) {
+        return null;
+      }
+
+      return {
+        id: dailySession.id,
+        session_type: dailySession.type,
+        status: dailySession.status,
+        local_day_key: dailySession.localDayKey,
+        started_at: dailySession.startedAt,
+        completed_at: dailySession.completedAt,
+        created_at: dailySession.createdAt,
+        updated_at: dailySession.updatedAt,
+      } as T;
+    }
+
     if (sql.includes("session_type = 'daily'")) {
       const [localDayKey] = params as [string];
       const dailySession = [...this.sessions.values()]
@@ -195,11 +229,60 @@ class FakeSessionAdapter implements LocalDatabaseAdapter {
       } as T;
     }
 
+    if (sql.includes("WHERE session_type = 'onboarding' AND status = 'completed'")) {
+      const completedOnboardingSession = [...this.sessions.values()].find(
+        (session) => session.type === 'onboarding' && session.status === 'completed'
+      );
+      return completedOnboardingSession ? ({ id: completedOnboardingSession.id } as T) : null;
+    }
+
+    if (sql.includes('WHERE id = ? AND status = \'completed\'')) {
+      const [sessionId] = params as [string];
+      const session = this.sessions.get(sessionId);
+
+      if (!session || session.status !== 'completed') {
+        return null;
+      }
+
+      return {
+        id: session.id,
+        session_type: session.type,
+        status: session.status,
+        local_day_key: session.localDayKey,
+        started_at: session.startedAt,
+        completed_at: session.completedAt,
+        created_at: session.createdAt,
+        updated_at: session.updatedAt,
+      } as T;
+    }
+
     if (sql.includes('FROM type_snapshots') && sql.includes('WHERE session_id = ?')) {
       const [sessionId] = params as [string];
       const snapshot = [...this.snapshots.values()]
         .filter((entry) => entry.source.sessionId === sessionId)
         .sort((a, b) => b.createdAt.toISOString().localeCompare(a.createdAt.toISOString()))[0];
+
+      if (!snapshot) {
+        return null;
+      }
+
+      return {
+        id: snapshot.id,
+        session_id: snapshot.source.sessionId ?? null,
+        current_type: snapshot.currentType,
+        axis_scores_json: JSON.stringify(snapshot.axisScores),
+        axis_strengths_json: JSON.stringify(snapshot.axisStrengths),
+        source_type: snapshot.source.type,
+        source_session_id: snapshot.source.sessionId ?? null,
+        question_count: snapshot.questionCount,
+        created_at: snapshot.createdAt.toISOString(),
+      } as T;
+    }
+
+    if (sql.includes('FROM type_snapshots') && sql.includes('ORDER BY created_at DESC, id DESC')) {
+      const snapshot = [...this.snapshots.values()].sort(
+        (a, b) => b.createdAt.toISOString().localeCompare(a.createdAt.toISOString()) || b.id.localeCompare(a.id)
+      )[0];
 
       if (!snapshot) {
         return null;
@@ -234,6 +317,45 @@ class FakeSessionAdapter implements LocalDatabaseAdapter {
           answer: answer.answer,
           answered_at: answer.answeredAt,
         })) as T[];
+    }
+
+    if (sql.includes('FROM sessions s') && sql.includes("WHERE s.status = 'completed'")) {
+      return [...this.sessions.values()]
+        .filter((session) => session.status === 'completed')
+        .sort(
+          (a, b) =>
+            (b.completedAt ?? '').localeCompare(a.completedAt ?? '') ||
+            b.startedAt.localeCompare(a.startedAt) ||
+            b.id.localeCompare(a.id)
+        )
+        .map((session) => {
+          const snapshot = [...this.snapshots.values()]
+            .filter((entry) => entry.source.sessionId === session.id)
+            .sort(
+              (a, b) =>
+                b.createdAt.toISOString().localeCompare(a.createdAt.toISOString()) || b.id.localeCompare(a.id)
+            )[0];
+
+          return {
+            id: session.id,
+            session_type: session.type,
+            status: session.status,
+            local_day_key: session.localDayKey,
+            started_at: session.startedAt,
+            completed_at: session.completedAt,
+            created_at: session.createdAt,
+            updated_at: session.updatedAt,
+            snapshot_id: snapshot?.id ?? null,
+            snapshot_session_id: snapshot?.source.sessionId ?? null,
+            current_type: snapshot?.currentType ?? null,
+            axis_scores_json: snapshot ? JSON.stringify(snapshot.axisScores) : null,
+            axis_strengths_json: snapshot ? JSON.stringify(snapshot.axisStrengths) : null,
+            source_type: snapshot?.source.type ?? null,
+            source_session_id: snapshot?.source.sessionId ?? null,
+            question_count: snapshot?.questionCount ?? null,
+            snapshot_created_at: snapshot?.createdAt.toISOString() ?? null,
+          };
+        }) as T[];
     }
 
     if (sql.includes('FROM type_snapshots')) {
@@ -340,5 +462,95 @@ describe('session lifecycle persistence helpers', () => {
 
     expect(storedForSession).toEqual(snapshot);
     expect(history).toEqual([snapshot]);
+  });
+
+  it('reads onboarding completion state for settings', async () => {
+    const adapter = new FakeSessionAdapter();
+    const session = await startOrResumeOnboardingSession(adapter, new Date('2026-01-01T08:00:00.000Z'));
+
+    expect(await hasCompletedOnboardingSession(adapter)).toBe(false);
+
+    await completeSession(adapter, session.id, new Date('2026-01-01T08:10:00.000Z'));
+
+    expect(await hasCompletedOnboardingSession(adapter)).toBe(true);
+  });
+
+  it('reads active daily session before falling back to the latest completed one', async () => {
+    const adapter = new FakeSessionAdapter();
+    const first = await getOrCreateDailySessionForLocalDay(adapter, '2026-01-01', new Date('2026-01-01T08:00:00.000Z'));
+    await completeSession(adapter, first.id, new Date('2026-01-01T08:05:00.000Z'));
+
+    const second = await getOrCreateDailySessionForLocalDay(adapter, '2026-01-02', new Date('2026-01-02T08:00:00.000Z'));
+    await completeSession(adapter, second.id, new Date('2026-01-02T08:05:00.000Z'));
+
+    const third = await getOrCreateDailySessionForLocalDay(adapter, '2026-01-03', new Date('2026-01-03T08:00:00.000Z'));
+
+    const active = await readActiveOrLatestDailySession(adapter);
+    expect(active?.id).toBe(third.id);
+
+    await completeSession(adapter, third.id, new Date('2026-01-03T08:05:00.000Z'));
+    const fallback = await readActiveOrLatestDailySession(adapter);
+    expect(fallback?.id).toBe(third.id);
+  });
+
+  it('reads completed history list and entry detail for journal', async () => {
+    const adapter = new FakeSessionAdapter();
+    const onboarding = await startOrResumeOnboardingSession(adapter, new Date('2026-01-01T08:00:00.000Z'));
+    await upsertSessionAnswer(adapter, onboarding.id, 'q-001', 'agree', new Date('2026-01-01T08:01:00.000Z'));
+    await completeSession(adapter, onboarding.id, new Date('2026-01-01T08:02:00.000Z'));
+
+    const daily = await getOrCreateDailySessionForLocalDay(adapter, '2026-01-02', new Date('2026-01-02T08:00:00.000Z'));
+    await upsertSessionAnswer(adapter, daily.id, 'q-002', 'disagree', new Date('2026-01-02T08:01:00.000Z'));
+    await completeSession(adapter, daily.id, new Date('2026-01-02T08:02:00.000Z'));
+
+    const snapshot: TypeSnapshot = {
+      id: 'snap-002',
+      currentType: 'ENTP',
+      axisScores: [],
+      axisStrengths: [],
+      createdAt: new Date('2026-01-02T08:03:00.000Z'),
+      source: { type: 'daily', sessionId: daily.id },
+      questionCount: 1,
+    };
+    await upsertTypeSnapshot(adapter, snapshot);
+
+    const history = await readCompletedSessionHistory(adapter);
+    const detail = await readCompletedSessionDetail(adapter, daily.id);
+    const truncated = await readCompletedSessionHistory(adapter, 1);
+
+    expect(history.map((entry) => entry.session.id)).toEqual([daily.id, onboarding.id]);
+    expect(history[0]?.snapshot).toEqual(snapshot);
+    expect(detail?.answers).toHaveLength(1);
+    expect(detail?.snapshot).toEqual(snapshot);
+    expect(truncated).toHaveLength(1);
+  });
+
+  it('reads current type snapshot for insights', async () => {
+    const adapter = new FakeSessionAdapter();
+    const onboarding = await startOrResumeOnboardingSession(adapter, new Date('2026-01-01T08:00:00.000Z'));
+    await completeSession(adapter, onboarding.id, new Date('2026-01-01T08:10:00.000Z'));
+
+    const firstSnapshot: TypeSnapshot = {
+      id: 'snap-003',
+      currentType: 'INTJ',
+      axisScores: [],
+      axisStrengths: [],
+      createdAt: new Date('2026-01-01T08:11:00.000Z'),
+      source: { type: 'onboarding', sessionId: onboarding.id },
+      questionCount: 12,
+    };
+
+    const secondSnapshot: TypeSnapshot = {
+      ...firstSnapshot,
+      id: 'snap-004',
+      currentType: 'INFJ',
+      createdAt: new Date('2026-01-02T08:11:00.000Z'),
+    };
+
+    await upsertTypeSnapshot(adapter, firstSnapshot);
+    await upsertTypeSnapshot(adapter, secondSnapshot);
+
+    const latest = await readLatestTypeSnapshot(adapter);
+    expect(latest).toEqual(secondSnapshot);
   });
 });

--- a/__tests__/session-lifecycle-test.ts
+++ b/__tests__/session-lifecycle-test.ts
@@ -320,7 +320,11 @@ class FakeSessionAdapter implements LocalDatabaseAdapter {
     }
 
     if (sql.includes('FROM sessions s') && sql.includes("WHERE s.status = 'completed'")) {
-      return [...this.sessions.values()]
+      const [limit] = params as [number | undefined];
+      const normalizedLimit =
+        typeof limit === 'number' && Number.isFinite(limit) && limit >= 0 ? Math.trunc(limit) : null;
+
+      const rows = [...this.sessions.values()]
         .filter((session) => session.status === 'completed')
         .sort(
           (a, b) =>
@@ -355,7 +359,9 @@ class FakeSessionAdapter implements LocalDatabaseAdapter {
             question_count: snapshot?.questionCount ?? null,
             snapshot_created_at: snapshot?.createdAt.toISOString() ?? null,
           };
-        }) as T[];
+        });
+
+      return (normalizedLimit === null ? rows : rows.slice(0, normalizedLimit)) as T[];
     }
 
     if (sql.includes('FROM type_snapshots')) {

--- a/lib/local-data/session-lifecycle.ts
+++ b/lib/local-data/session-lifecycle.ts
@@ -23,6 +23,17 @@ export type PersistedSessionAnswer = {
   answeredAt: string;
 };
 
+export type PersistedHistoryEntry = {
+  session: PersistedSession;
+  snapshot: TypeSnapshot | null;
+};
+
+export type PersistedSessionDetail = {
+  session: PersistedSession;
+  answers: PersistedSessionAnswer[];
+  snapshot: TypeSnapshot | null;
+};
+
 type SessionRow = {
   id: string;
   session_type: PersistedSessionType;
@@ -237,6 +248,34 @@ export async function completeSession(
   );
 }
 
+export async function hasCompletedOnboardingSession(adapter: LocalDatabaseAdapter): Promise<boolean> {
+  const row = await adapter.getFirstAsync<{ id: string }>(
+    `SELECT id
+     FROM sessions
+     WHERE session_type = 'onboarding' AND status = 'completed'
+     LIMIT 1;`
+  );
+
+  return row != null;
+}
+
+export async function readActiveOrLatestDailySession(
+  adapter: LocalDatabaseAdapter
+): Promise<PersistedSession | null> {
+  const row = await adapter.getFirstAsync<SessionRow>(
+    `SELECT id, session_type, status, local_day_key, started_at, completed_at, created_at, updated_at
+     FROM sessions
+     WHERE session_type = 'daily'
+     ORDER BY
+      CASE WHEN status = 'in_progress' THEN 0 ELSE 1 END ASC,
+      started_at DESC,
+      id DESC
+     LIMIT 1;`
+  );
+
+  return row ? mapSessionRow(row) : null;
+}
+
 function mapTypeSnapshotRow(row: TypeSnapshotRow): TypeSnapshot {
   return {
     id: row.id,
@@ -312,6 +351,106 @@ export async function readAllTypeSnapshots(adapter: LocalDatabaseAdapter): Promi
   );
 
   return rows.map(mapTypeSnapshotRow);
+}
+
+export async function readLatestTypeSnapshot(
+  adapter: LocalDatabaseAdapter
+): Promise<TypeSnapshot | null> {
+  const row = await adapter.getFirstAsync<TypeSnapshotRow>(
+    `SELECT id, session_id, current_type, axis_scores_json, axis_strengths_json, source_type, source_session_id, question_count, created_at
+     FROM type_snapshots
+     ORDER BY created_at DESC, id DESC
+     LIMIT 1;`
+  );
+
+  return row ? mapTypeSnapshotRow(row) : null;
+}
+
+export async function readCompletedSessionHistory(
+  adapter: LocalDatabaseAdapter,
+  limit?: number
+): Promise<PersistedHistoryEntry[]> {
+  const rows = await adapter.getAllAsync<
+    SessionRow & {
+      snapshot_id: string | null;
+      snapshot_session_id: string | null;
+      current_type: string | null;
+      axis_scores_json: string | null;
+      axis_strengths_json: string | null;
+      source_type: TypeSnapshot['source']['type'] | null;
+      source_session_id: string | null;
+      question_count: number | null;
+      snapshot_created_at: string | null;
+    }
+  >(
+    `SELECT
+      s.id, s.session_type, s.status, s.local_day_key, s.started_at, s.completed_at, s.created_at, s.updated_at,
+      ts.id AS snapshot_id, ts.session_id AS snapshot_session_id, ts.current_type, ts.axis_scores_json, ts.axis_strengths_json,
+      ts.source_type, ts.source_session_id, ts.question_count, ts.created_at AS snapshot_created_at
+     FROM sessions s
+     LEFT JOIN type_snapshots ts ON ts.id = (
+      SELECT candidate.id
+      FROM type_snapshots candidate
+      WHERE candidate.session_id = s.id
+      ORDER BY candidate.created_at DESC, candidate.id DESC
+      LIMIT 1
+     )
+     WHERE s.status = 'completed'
+     ORDER BY s.completed_at DESC, s.started_at DESC, s.id DESC;`
+  );
+
+  const history = rows.map((row) => ({
+    session: mapSessionRow(row),
+    snapshot:
+      row.snapshot_id &&
+      row.current_type &&
+      row.axis_scores_json &&
+      row.axis_strengths_json &&
+      row.source_type &&
+      row.question_count != null &&
+      row.snapshot_created_at
+        ? mapTypeSnapshotRow({
+            id: row.snapshot_id,
+            session_id: row.snapshot_session_id,
+            current_type: row.current_type,
+            axis_scores_json: row.axis_scores_json,
+            axis_strengths_json: row.axis_strengths_json,
+            source_type: row.source_type,
+            source_session_id: row.source_session_id,
+            question_count: row.question_count,
+            created_at: row.snapshot_created_at,
+          })
+        : null,
+  }));
+
+  return typeof limit === 'number' ? history.slice(0, Math.max(0, limit)) : history;
+}
+
+export async function readCompletedSessionDetail(
+  adapter: LocalDatabaseAdapter,
+  sessionId: string
+): Promise<PersistedSessionDetail | null> {
+  const sessionRow = await adapter.getFirstAsync<SessionRow>(
+    `SELECT id, session_type, status, local_day_key, started_at, completed_at, created_at, updated_at
+     FROM sessions
+     WHERE id = ? AND status = 'completed'
+     LIMIT 1;`,
+    sessionId
+  );
+
+  if (!sessionRow) {
+    return null;
+  }
+
+  const session = mapSessionRow(sessionRow);
+  const answers = await readSessionAnswers(adapter, sessionId);
+  const snapshot = await readSessionTypeSnapshot(adapter, sessionId);
+
+  return {
+    session,
+    answers,
+    snapshot,
+  };
 }
 
 export function toLocalDayKey(date: Date): string {

--- a/lib/local-data/session-lifecycle.ts
+++ b/lib/local-data/session-lifecycle.ts
@@ -370,6 +370,7 @@ export async function readCompletedSessionHistory(
   adapter: LocalDatabaseAdapter,
   limit?: number
 ): Promise<PersistedHistoryEntry[]> {
+  const normalizedLimit = typeof limit === 'number' ? Math.max(0, Math.trunc(limit)) : null;
   const rows = await adapter.getAllAsync<
     SessionRow & {
       snapshot_id: string | null;
@@ -396,7 +397,9 @@ export async function readCompletedSessionHistory(
       LIMIT 1
      )
      WHERE s.status = 'completed'
-     ORDER BY s.completed_at DESC, s.started_at DESC, s.id DESC;`
+     ORDER BY s.completed_at DESC, s.started_at DESC, s.id DESC
+     LIMIT ?;`,
+    normalizedLimit ?? -1
   );
 
   const history = rows.map((row) => ({
@@ -423,7 +426,7 @@ export async function readCompletedSessionHistory(
         : null,
   }));
 
-  return typeof limit === 'number' ? history.slice(0, Math.max(0, limit)) : history;
+  return history;
 }
 
 export async function readCompletedSessionDetail(


### PR DESCRIPTION
closes https://github.com/hugo-hsi-dev/swipe-check/issues/37
### Motivation
- Provide the missing persisted read-side helpers required by Today, Journal, Insights, and Settings so screens read canonical, persisted state instead of in-memory assumptions.
- Expose queries for onboarding completion, active/unfinished daily session, completed history entries with snapshots, session detail, and the latest type snapshot to support UI read paths.

### Description
- Added new types `PersistedHistoryEntry` and `PersistedSessionDetail` and new read helpers `hasCompletedOnboardingSession`, `readActiveOrLatestDailySession`, `readCompletedSessionHistory`, `readCompletedSessionDetail`, and `readLatestTypeSnapshot` in `lib/local-data/session-lifecycle.ts`.
- `readCompletedSessionHistory` joins sessions to the latest per-session snapshot so the journal list can show the latest snapshot for each completed entry and accepts an optional `limit` parameter.
- `readActiveOrLatestDailySession` returns an in-progress daily session if present, otherwise falls back to the most-recent completed daily session using the ordering `CASE WHEN status = 'in_progress' THEN 0 ELSE 1 END, started_at DESC, id DESC`.
- Updated `__tests__/session-lifecycle-test.ts` (and the test `FakeSessionAdapter`) to cover the new helpers and ensure behavior for onboarding completion, active/ latest daily session selection, completed history listing/detail reads, and reading the current/latest type snapshot.

### Testing
- Ran `pnpm lint` and `pnpm typecheck` and both completed with no errors.
- Ran unit tests with `pnpm test:ci` and all test suites passed (7 suites, 65 tests) after iterating on a failing test during development.
- Ran the focused test file `pnpm test:ci -- __tests__/session-lifecycle-test.ts` while developing the helpers and verified that the file's tests pass before finalizing changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc21ee9b2c832093a2a984d695f061)