### PR TITLE
Fix local data integrity gaps

### DIFF
--- a/lib/local-data/session-lifecycle.ts
+++ b/lib/local-data/session-lifecycle.ts
@@ -192,6 +192,18 @@ export async function upsertSessionAnswer(
   answer: QuestionResponse,
   answeredAt = new Date()
 ): Promise<void> {
+  const session = await adapter.getFirstAsync<{ status: PersistedSessionStatus }>(
+    `SELECT status
+     FROM sessions
+     WHERE id = ?
+     LIMIT 1;`,
+    sessionId
+  );
+
+  if (session?.status === 'completed') {
+    throw new Error('Cannot modify answers for a completed session.');
+  }
+
   const answeredAtIso = answeredAt.toISOString();
 
   await adapter.runAsync(

--- a/lib/local-data/session-lifecycle.ts
+++ b/lib/local-data/session-lifecycle.ts
@@ -192,24 +192,17 @@ export async function upsertSessionAnswer(
   answer: QuestionResponse,
   answeredAt = new Date()
 ): Promise<void> {
-  const session = await adapter.getFirstAsync<{ status: PersistedSessionStatus }>(
-    `SELECT status
-     FROM sessions
-     WHERE id = ?
-     LIMIT 1;`,
-    sessionId
-  );
-
-  if (session?.status === 'completed') {
-    throw new Error('Cannot modify answers for a completed session.');
-  }
-
   const answeredAtIso = answeredAt.toISOString();
 
-  await adapter.runAsync(
+  const result = await adapter.runAsync(
     `INSERT INTO session_answers
      (session_id, question_id, answer, answered_at, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?)
+     SELECT ?, ?, ?, ?, ?, ?
+     WHERE EXISTS (
+       SELECT 1
+       FROM sessions
+       WHERE id = ? AND status = 'in_progress'
+     )
      ON CONFLICT(session_id, question_id) DO UPDATE SET
        answer = excluded.answer,
        answered_at = excluded.answered_at,
@@ -219,8 +212,13 @@ export async function upsertSessionAnswer(
     answer,
     answeredAtIso,
     answeredAtIso,
-    answeredAtIso
+    answeredAtIso,
+    sessionId
   );
+
+  if (typeof result === 'object' && result !== null && 'changes' in result && (result as { changes?: number }).changes === 0) {
+    throw new Error('Cannot modify answers for a completed session.');
+  }
 }
 
 export async function readSessionAnswers(

--- a/lib/local-data/sqlite.ts
+++ b/lib/local-data/sqlite.ts
@@ -32,6 +32,7 @@ class ExpoSQLiteAdapter implements LocalDatabaseAdapter {
 
 async function openAdapter(dbName: string): Promise<ExpoSQLiteAdapter> {
   const db = await openDatabaseAsync(dbName);
+  await db.execAsync('PRAGMA foreign_keys = ON;');
   return new ExpoSQLiteAdapter(db);
 }
 


### PR DESCRIPTION
## Summary
- Block answer writes to completed sessions so finished history stays read-only.
- Enable SQLite foreign keys on connection open so cascade and set-null rules actually apply.

## Verification
- `pnpm lint`
- `pnpm typecheck`