### PR TITLE
Epic 06.1: Shape the completed-history data surface (#82)

### DIFF
--- a/__tests__/session-lifecycle-test.ts
+++ b/__tests__/session-lifecycle-test.ts
@@ -9,6 +9,7 @@ import {
   readAllTypeSnapshots,
   readCompletedSessionDetail,
   readCompletedSessionHistory,
+  readLatestCompletedSessionForDay,
   readLatestTypeSnapshot,
   readSessionAnswers,
   readSessionTypeSnapshot,
@@ -356,6 +357,55 @@ class FakeSessionAdapter implements LocalDatabaseAdapter {
   }
 
   async getAllAsync<T>(sql: string, ...params: (string | number | null)[]): Promise<T[]> {
+    if (
+      sql.includes('FROM sessions s') &&
+      sql.includes('LEFT JOIN type_snapshots ts') &&
+      sql.includes("WHERE s.status = 'completed' AND s.local_day_key = ?") &&
+      sql.includes('ORDER BY s.completed_at DESC') &&
+      sql.includes('LIMIT 1')
+    ) {
+      const [localDayKey] = params as [string];
+      const rows = [...this.sessions.values()]
+        .filter((session) => session.status === 'completed' && session.localDayKey === localDayKey)
+        .sort(
+          (a, b) =>
+            (b.completedAt ?? '').localeCompare(a.completedAt ?? '') ||
+            b.startedAt.localeCompare(a.startedAt) ||
+            b.id.localeCompare(a.id)
+        )
+        .slice(0, 1)
+        .map((session) => {
+          const snapshot = [...this.snapshots.values()]
+            .filter((entry) => entry.source.sessionId === session.id)
+            .sort(
+              (a, b) =>
+                b.createdAt.toISOString().localeCompare(a.createdAt.toISOString()) || b.id.localeCompare(a.id)
+            )[0];
+
+          return {
+            id: session.id,
+            session_type: session.type,
+            status: session.status,
+            local_day_key: session.localDayKey,
+            started_at: session.startedAt,
+            completed_at: session.completedAt,
+            created_at: session.createdAt,
+            updated_at: session.updatedAt,
+            snapshot_id: snapshot?.id ?? null,
+            snapshot_session_id: snapshot?.source.sessionId ?? null,
+            current_type: snapshot?.currentType ?? null,
+            axis_scores_json: snapshot ? JSON.stringify(snapshot.axisScores) : null,
+            axis_strengths_json: snapshot ? JSON.stringify(snapshot.axisStrengths) : null,
+            source_type: snapshot?.source.type ?? null,
+            source_session_id: snapshot?.source.sessionId ?? null,
+            question_count: snapshot?.questionCount ?? null,
+            snapshot_created_at: snapshot?.createdAt.toISOString() ?? null,
+          };
+        });
+
+      return rows as T[];
+    }
+
     if (sql.includes('FROM sessions') && sql.includes("session_type = 'onboarding'")) {
       return [...this.sessions.values()]
         .filter((session) => session.type === 'onboarding')
@@ -952,5 +1002,69 @@ describe('onboarding assessment controller', () => {
 
     await completeOnboardingSession(adapter, session.id, completeSnapshot);
     expect(await hasCompletedOnboardingSession(adapter)).toBe(true);
+  });
+
+  it('returns latest completed session for a given day, even if a later non-daily session completed same day', async () => {
+    const adapter = new FakeSessionAdapter();
+    const todayKey = '2026-01-15';
+
+    const day1Session = await getOrCreateDailySessionForLocalDay(adapter, todayKey, new Date('2026-01-15T08:00:00.000Z'));
+
+    await upsertSessionAnswer(adapter, day1Session.id, 'q-013', 'agree', new Date('2026-01-15T08:02:00.000Z'));
+    await upsertSessionAnswer(adapter, day1Session.id, 'q-014', 'disagree', new Date('2026-01-15T08:03:00.000Z'));
+
+    const day1Snapshot: TypeSnapshot = {
+      id: 'snap-daily-015',
+      currentType: 'INTJ',
+      axisScores: [],
+      axisStrengths: [],
+      createdAt: new Date('2026-01-15T08:05:00.000Z'),
+      source: { type: 'daily', sessionId: day1Session.id },
+      questionCount: 2,
+    };
+
+    await completeSession(adapter, day1Session.id, new Date('2026-01-15T08:06:00.000Z'));
+    await upsertTypeSnapshot(adapter, day1Snapshot);
+
+    const onboarding = await startOrResumeOnboardingSession(adapter, new Date('2026-01-15T12:00:00.000Z'));
+
+    for (let i = 1; i <= 12; i++) {
+      await upsertSessionAnswer(
+        adapter,
+        onboarding.id,
+        `q-${String(i).padStart(3, '0')}`,
+        'agree',
+        new Date(`2026-01-15T12:${String(i).padStart(2, '0')}:00.000Z`)
+      );
+    }
+
+    const onboardingSnapshot: TypeSnapshot = {
+      id: 'snap-onboarding-001',
+      currentType: 'ESTP',
+      axisScores: [],
+      axisStrengths: [],
+      createdAt: new Date('2026-01-15T12:15:00.000Z'),
+      source: { type: 'onboarding', sessionId: onboarding.id },
+      questionCount: 12,
+    };
+
+    await completeOnboardingSession(adapter, onboarding.id, onboardingSnapshot);
+
+    const day1Completed = await readLatestCompletedSessionForDay(adapter, todayKey);
+
+    expect(day1Completed).not.toBeNull();
+    expect(day1Completed?.session.id).toBe(day1Session.id);
+    expect(day1Completed?.session.type).toBe('daily');
+    expect(day1Completed?.session.status).toBe('completed');
+    expect(day1Completed?.session.localDayKey).toBe(todayKey);
+  });
+
+  it('returns null when no completed sessions exist for the given day', async () => {
+    const adapter = new FakeSessionAdapter();
+    const futureDayKey = '2026-12-31';
+
+    const result = await readLatestCompletedSessionForDay(adapter, futureDayKey);
+
+    expect(result).toBeNull();
   });
 });

--- a/hooks/use-journal-data.ts
+++ b/hooks/use-journal-data.ts
@@ -4,6 +4,7 @@ import { getSQLiteDatabase } from '@/lib/local-data/sqlite-runtime';
 import {
   readCompletedSessionHistory,
   readCompletedSessionDetail,
+  readLatestCompletedSessionForDay,
   toLocalDayKey,
   type PersistedHistoryEntry,
   type PersistedSessionDetail,
@@ -121,19 +122,44 @@ export function useCurrentDayCompletedSession(): {
   isLoading: boolean;
   error: Error | null;
 } {
-  const { entries, isLoading, error } = useJournalHistory(1);
-  const todayKey = getTodayLocalDayKey();
+  const [entry, setEntry] = useState<PersistedHistoryEntry | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
 
-  const currentDayEntry =
-    entries.length > 0 &&
-    entries[0].session.status === 'completed' &&
-    entries[0].session.localDayKey === todayKey
-      ? entries[0]
-      : null;
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadTodayEntry() {
+      try {
+        const db = await getSQLiteDatabase();
+        const todayKey = getTodayLocalDayKey();
+        const result = await readLatestCompletedSessionForDay(db, todayKey);
+
+        if (isMounted) {
+          setEntry(result);
+          setError(null);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadTodayEntry();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   return {
-    entry: currentDayEntry,
-    isCurrentDay: currentDayEntry !== null,
+    entry,
+    isCurrentDay: entry !== null,
     isLoading,
     error,
   };

--- a/hooks/use-journal-data.ts
+++ b/hooks/use-journal-data.ts
@@ -4,12 +4,16 @@ import { getSQLiteDatabase } from '@/lib/local-data/sqlite-runtime';
 import {
   readCompletedSessionHistory,
   readCompletedSessionDetail,
+  toLocalDayKey,
   type PersistedHistoryEntry,
   type PersistedSessionDetail,
 } from '@/lib/local-data/session-lifecycle';
 
 type JournalHistoryState = {
   entries: PersistedHistoryEntry[];
+  isEmpty: boolean;
+  isSingleEntry: boolean;
+  isMultiEntry: boolean;
   isLoading: boolean;
   error: Error | null;
 };
@@ -49,7 +53,11 @@ export function useJournalHistory(limit?: number): JournalHistoryState {
     };
   }, [limit]);
 
-  return { entries, isLoading, error };
+  const isEmpty = !isLoading && entries.length === 0;
+  const isSingleEntry = !isLoading && entries.length === 1;
+  const isMultiEntry = !isLoading && entries.length > 1;
+
+  return { entries, isEmpty, isSingleEntry, isMultiEntry, isLoading, error };
 }
 
 type JournalEntryDetailState = {
@@ -101,4 +109,32 @@ export function useJournalEntryDetail(sessionId: string | null): JournalEntryDet
   }, [sessionId]);
 
   return { detail, isLoading, error };
+}
+
+function getTodayLocalDayKey(): string {
+  return toLocalDayKey(new Date());
+}
+
+export function useCurrentDayCompletedSession(): {
+  entry: PersistedHistoryEntry | null;
+  isCurrentDay: boolean;
+  isLoading: boolean;
+  error: Error | null;
+} {
+  const { entries, isLoading, error } = useJournalHistory(1);
+  const todayKey = getTodayLocalDayKey();
+
+  const currentDayEntry =
+    entries.length > 0 &&
+    entries[0].session.status === 'completed' &&
+    entries[0].session.localDayKey === todayKey
+      ? entries[0]
+      : null;
+
+  return {
+    entry: currentDayEntry,
+    isCurrentDay: currentDayEntry !== null,
+    isLoading,
+    error,
+  };
 }

--- a/lib/local-data/session-lifecycle.ts
+++ b/lib/local-data/session-lifecycle.ts
@@ -538,6 +538,71 @@ export async function readCompletedSessionHistory(
   return history;
 }
 
+export async function readLatestCompletedSessionForDay(
+  adapter: LocalDatabaseAdapter,
+  localDayKey: string
+): Promise<PersistedHistoryEntry | null> {
+  const rows = await adapter.getAllAsync<
+    SessionRow & {
+      snapshot_id: string | null;
+      snapshot_session_id: string | null;
+      current_type: string | null;
+      axis_scores_json: string | null;
+      axis_strengths_json: string | null;
+      source_type: TypeSnapshot['source']['type'] | null;
+      source_session_id: string | null;
+      question_count: number | null;
+      snapshot_created_at: string | null;
+    }
+  >(
+    `SELECT
+       s.id, s.session_type, s.status, s.local_day_key, s.started_at, s.completed_at, s.created_at, s.updated_at,
+       ts.id AS snapshot_id, ts.session_id AS snapshot_session_id, ts.current_type, ts.axis_scores_json, ts.axis_strengths_json,
+       ts.source_type, ts.source_session_id, ts.question_count, ts.created_at AS snapshot_created_at
+      FROM sessions s
+      LEFT JOIN type_snapshots ts ON ts.id = (
+       SELECT candidate.id
+       FROM type_snapshots candidate
+       WHERE candidate.session_id = s.id
+       ORDER BY candidate.created_at DESC, candidate.id DESC
+       LIMIT 1
+      )
+      WHERE s.status = 'completed' AND s.local_day_key = ?
+      ORDER BY s.completed_at DESC, s.started_at DESC, s.id DESC
+      LIMIT 1;`,
+    localDayKey
+  );
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const row = rows[0];
+  return {
+    session: mapSessionRow(row),
+    snapshot:
+      row.snapshot_id &&
+      row.current_type &&
+      row.axis_scores_json &&
+      row.axis_strengths_json &&
+      row.source_type &&
+      row.question_count != null &&
+      row.snapshot_created_at
+        ? mapTypeSnapshotRow({
+            id: row.snapshot_id,
+            session_id: row.snapshot_session_id,
+            current_type: row.current_type,
+            axis_scores_json: row.axis_scores_json,
+            axis_strengths_json: row.axis_strengths_json,
+            source_type: row.source_type,
+            source_session_id: row.source_session_id,
+            question_count: row.question_count,
+            created_at: row.snapshot_created_at,
+          })
+        : null,
+  };
+}
+
 export async function readCompletedSessionDetail(
   adapter: LocalDatabaseAdapter,
   sessionId: string


### PR DESCRIPTION
## Summary

- Enhanced `useJournalHistory` with computed state properties (`isEmpty`, `isSingleEntry`, `isMultiEntry`) to help UI distinguish between empty, single-entry, and multi-entry states
- Added `useCurrentDayCompletedSession` hook that returns today's completed session when one exists, providing easy access to current-day completed entry with `isCurrentDay` boolean flag
- All history reads remain read-only with no editing or backfilling capabilities

## Acceptance Criteria

- ✅ Completed entries are returned in deterministic reverse chronological order (already handled by `readCompletedSessionHistory`)
- ✅ Journal callers can distinguish empty, single-entry, and multi-entry states via new computed properties
- ✅ History reads never imply editing or backfilling past sessions (kept read-only)

## Validation

- `pnpm typecheck` passes
- `pnpm test:ci` passes (151 tests)
- `pnpm lint` passes

Closes #82