### PR TITLE
Clarify epic-to-issues routing in agent guidance

### DIFF
--- a/.agents/skills/epic-issue-orchestration/SKILL.md
+++ b/.agents/skills/epic-issue-orchestration/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: epic-issue-orchestration
-description: Split product epics into GitHub issue hierarchies with one tracking epic, real subissues, and blocking dependencies. Use when converting a product or architecture epic into issue-ready work items for autonomous agents.
+description: Mandatory for requests that transform an epic, product spec, PRD, roadmap, or domain brief into GitHub issues, subissues, or dependency graphs. Use when creating issue hierarchies from product epics.
 license: Complete terms in LICENSE.txt
 ---
 
 This skill turns an epic document into a structured GitHub issue tree that an autonomous agent can execute without reinterpreting the domain or renegotiating scope mid-flight.
+
+This skill is the required entrypoint for epic-to-issues work. If the user is asking for issue breakdowns, tracking epics, subissues, or dependency ordering from a spec/epic document, use this skill instead of generic issue creation.
 
 ## When To Use
 - The user gives you a product epic, spec, or domain brief and wants GitHub issues created from it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,22 @@
 This file is for coding agents working in `/home/hugo/Projects/swipe-check`.
 It summarizes the repository's build, lint, test, and style expectations based on the current codebase.
 
+## Mandatory Epic-to-Issues Routing
+
+If the user asks to convert an epic, product spec, PRD, roadmap, or domain brief into GitHub issues, subissues, or a dependency graph, you must invoke `epic-orchestrator` first.
+
+This includes requests phrased like:
+- "make issues for this epic"
+- "break this down into issues"
+- "turn this spec into GitHub issues"
+- "create an issue hierarchy"
+- "split this epic into subissues"
+- "plan the work from this brief"
+
+Do not create the issues manually with generic GitHub commands until `epic-orchestrator` has run.
+
+If the request is ambiguous but mentions an epic/spec/issues/dependencies, default to `epic-orchestrator`.
+
 ## Project Summary
 
 - Framework: Expo + React Native + Expo Router


### PR DESCRIPTION
## Summary
- Updated the epic-issue-orchestration skill description to clarify it is the mandatory entry point for epic-to-issues work
- Added "Mandatory Epic-to-Issues Routing" section to AGENTS.md with clear triggers and examples
- Ensures agents automatically use the `epic-orchestrator` agent when users ask to break down epics, specs, or PRDs into GitHub issues

## Changes
- `.agents/skills/epic-issue-orchestration/SKILL.md`: Clarified description and added routing guidance
- `AGENTS.md`: New section defining when to invoke epic-orchestrator instead of generic issue creation