### PR TITLE
Update opencode workflow to use zai-glm-4.7 model

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
         with:
-          model: opencode-go/kimi-k2.5
+          model: cerebras/zai-glm-4.7


### PR DESCRIPTION
## Summary
- Updated workflow to use `CEREBRAS_API_KEY` instead of `OPENCODE_API_KEY`
- Changed model from `opencode-go/kimi-k2.5` to `cerebras/zai-glm-4.7`