### PR TITLE
Add onboarding as a special journal entry

### DIFF
--- a/__tests__/journal-history-e2e-test.tsx
+++ b/__tests__/journal-history-e2e-test.tsx
@@ -223,6 +223,103 @@ describe('Journal History Edge Cases', () => {
     });
   });
 
+  describe('Onboarding Filtering from Journal', () => {
+    it('should return all completed sessions from hook, including onboarding', async () => {
+      // Arrange: Only onboarding completed
+      const session = createMockSession({
+        id: 'session-onboarding',
+        type: 'onboarding',
+        localDayKey: '2024-04-01',
+        completedAt: new Date('2024-04-01T10:00:00'),
+      });
+      const snapshot = createMockSnapshot({
+        id: 'snap-onboarding',
+        sessionId: session.id,
+        currentType: 'INTJ',
+        questionCount: 12,
+        sourceType: 'onboarding',
+      });
+
+      mockDbState.historyEntries = [{ session, snapshot }];
+
+      // Act
+      const { result } = renderHook(() => useJournalHistory());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert: Hook still returns all completed sessions (UI layer filters)
+      expect(result.current.entries).toHaveLength(1);
+      expect(result.current.entries[0].session.type).toBe('onboarding');
+    });
+
+    it('should return all completed sessions from hook when both onboarding and daily exist', async () => {
+      // Arrange: Onboarding + daily sessions
+      const onboarding = createMockSession({
+        id: 'session-onboarding',
+        type: 'onboarding',
+        localDayKey: '2024-04-01',
+        completedAt: new Date('2024-04-01T10:00:00'),
+      });
+      const onboardingSnapshot = createMockSnapshot({
+        id: 'snap-onboarding',
+        sessionId: onboarding.id,
+        currentType: 'INTJ',
+        questionCount: 12,
+        sourceType: 'onboarding',
+      });
+
+      const daily1 = createMockSession({
+        id: 'session-daily-1',
+        type: 'daily',
+        localDayKey: '2024-04-02',
+        completedAt: new Date('2024-04-02T10:00:00'),
+      });
+      const daily1Snapshot = createMockSnapshot({
+        id: 'snap-daily-1',
+        sessionId: daily1.id,
+        currentType: 'ENTJ',
+        questionCount: 4,
+        sourceType: 'daily',
+      });
+
+      const daily2 = createMockSession({
+        id: 'session-daily-2',
+        type: 'daily',
+        localDayKey: '2024-04-03',
+        completedAt: new Date('2024-04-03T10:00:00'),
+      });
+      const daily2Snapshot = createMockSnapshot({
+        id: 'snap-daily-2',
+        sessionId: daily2.id,
+        currentType: 'ENTP',
+        questionCount: 4,
+        sourceType: 'daily',
+      });
+
+      mockDbState.historyEntries = [
+        { session: onboarding, snapshot: onboardingSnapshot },
+        { session: daily2, snapshot: daily2Snapshot },
+        { session: daily1, snapshot: daily1Snapshot },
+      ];
+
+      // Act
+      const { result } = renderHook(() => useJournalHistory());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert: Hook returns all completed sessions (UI layer filters out onboarding)
+      expect(result.current.entries).toHaveLength(3);
+      expect(result.current.entries[0].session.id).toBe('session-daily-2');
+      expect(result.current.entries[1].session.id).toBe('session-daily-1');
+      expect(result.current.entries[2].session.id).toBe('session-onboarding');
+      expect(result.current.isMultiEntry).toBe(true);
+    });
+  });
+
   describe('Single Entry State - One Completed Day', () => {
     it('should display single onboarding entry after completion', async () => {
       // Arrange: One completed onboarding session
@@ -467,7 +564,7 @@ const snapshot = createMockSnapshot({
     });
   });
 
-  describe('Today Session Separation', () => {
+describe('Today Session Separation', () => {
     it('should identify today as separate from past entries', async () => {
       const today = new Date('2024-04-03T10:00:00');
       const dayKey = '2024-04-03';
@@ -538,7 +635,7 @@ const snapshot = createMockSnapshot({
       expect(result.current.entry).toBeNull();
     });
 
-    it('should support filtering today from history entries', async () => {
+    it('should not de-dupe today from history since the screen handles it', async () => {
       const today = new Date('2024-04-03T10:00:00');
       const dayKey = '2024-04-03';
 
@@ -575,29 +672,13 @@ const snapshot = createMockSnapshot({
         { session: todaySession, snapshot: todaySnapshot },
       ];
 
-      const { result: todayResult } = renderHook(() => useCurrentDayCompletedSession());
       const { result: historyResult } = renderHook(() => useJournalHistory());
 
       await waitFor(() => {
-        expect(todayResult.current.isLoading).toBe(false);
         expect(historyResult.current.isLoading).toBe(false);
       });
 
-      const todayEntry = todayResult.current.entry;
-      const historyEntries = historyResult.current.entries;
-
-      expect(todayEntry).not.toBeNull();
-      expect(todayEntry?.session.id).toBe('session-today');
-
-      expect(historyEntries).toHaveLength(2);
-
-      const filteredEntries = historyEntries.filter((entry) => {
-        if (!todayEntry) return true;
-        return entry.session.id !== todayEntry.session.id;
-      });
-
-      expect(filteredEntries).toHaveLength(1);
-      expect(filteredEntries[0].session.id).toBe('session-past');
+      expect(historyResult.current.entries).toHaveLength(2);
     });
   });
 

--- a/__tests__/journal-ui-test.tsx
+++ b/__tests__/journal-ui-test.tsx
@@ -1,0 +1,305 @@
+import { waitFor, render, fireEvent } from '@testing-library/react-native';
+import { router } from 'expo-router';
+import { HeroUINativeProvider } from 'heroui-native';
+
+import JournalScreen from '@/app/(tabs)/journal';
+
+jest.mock('expo-router', () => ({
+  router: {
+    push: jest.fn(),
+  },
+  useLocalSearchParams: jest.fn(() => ({})),
+}));
+
+jest.mock('@/hooks/use-journal-data', () => ({
+  useJournalHistory: jest.fn(),
+  useCurrentDayCompletedSession: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: jest.fn(() => 'light'),
+}));
+
+jest.mock('@/lib/local-data/sqlite-runtime', () => ({
+  getSQLiteDatabase: jest.fn(() => Promise.resolve({})),
+}));
+
+const { useJournalHistory, useCurrentDayCompletedSession } = require('@/hooks/use-journal-data');
+
+describe('Journal Screen UI States', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Fully Empty State', () => {
+    it('should show empty state when no history exists', async () => {
+      useJournalHistory.mockReturnValue({
+        entries: [],
+        isLoading: false,
+        isLoadingMore: false,
+        hasMore: false,
+        error: null,
+        loadMore: jest.fn(),
+      });
+
+      useCurrentDayCompletedSession.mockReturnValue({
+        entry: null,
+        isCurrentDay: false,
+        isLoading: false,
+        error: null,
+      });
+
+      const { getByText } = render(
+        <HeroUINativeProvider>
+          <JournalScreen />
+        </HeroUINativeProvider>
+      );
+
+      await waitFor(() => {
+        expect(getByText('Your Journal is Empty')).toBeTruthy();
+        expect(getByText('Complete daily check-ins to build your history.')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('Onboarding-Only State', () => {
+    it('should show baseline section with onboarding entry when only onboarding exists', async () => {
+      const onboardingEntry = {
+        session: {
+          id: 'session-onboarding',
+          type: 'onboarding' as const,
+          status: 'completed' as const,
+          localDayKey: '2024-04-01',
+          startedAt: '2024-04-01T09:00:00.000Z',
+          completedAt: '2024-04-01T09:15:00.000Z',
+          createdAt: '2024-04-01T09:00:00.000Z',
+          updatedAt: '2024-04-01T09:15:00.000Z',
+        },
+        snapshot: {
+          id: 'snap-onboarding',
+          currentType: 'INTJ',
+          axisScores: [],
+          axisStrengths: [],
+          questionCount: 12,
+          createdAt: new Date('2024-04-01T09:16:00.000Z'),
+          source: { type: 'onboarding' as const, sessionId: 'session-onboarding' },
+        },
+      };
+
+      useJournalHistory.mockReturnValue({
+        entries: [onboardingEntry],
+        isLoading: false,
+        isLoadingMore: false,
+        hasMore: false,
+        error: null,
+        loadMore: jest.fn(),
+      });
+
+      useCurrentDayCompletedSession.mockReturnValue({
+        entry: null,
+        isCurrentDay: false,
+        isLoading: false,
+        error: null,
+      });
+
+      const { getByText } = render(
+        <HeroUINativeProvider>
+          <JournalScreen />
+        </HeroUINativeProvider>
+      );
+
+      await waitFor(() => {
+        expect(getByText('Baseline')).toBeTruthy();
+        expect(getByText('Onboarding')).toBeTruthy();
+        expect(getByText('INTJ')).toBeTruthy();
+      });
+
+      fireEvent.press(getByText('Onboarding'));
+      expect(router.push).toHaveBeenCalledWith('/journal/session-onboarding');
+    });
+  });
+
+  describe('Mixed History State', () => {
+    it('should show both onboarding baseline and daily entries when both exist', async () => {
+      const onboardingEntry = {
+        session: {
+          id: 'session-onboarding',
+          type: 'onboarding' as const,
+          status: 'completed' as const,
+          localDayKey: '2024-04-01',
+          startedAt: '2024-04-01T09:00:00.000Z',
+          completedAt: '2024-04-01T09:15:00.000Z',
+          createdAt: '2024-04-01T09:00:00.000Z',
+          updatedAt: '2024-04-01T09:15:00.000Z',
+        },
+        snapshot: {
+          id: 'snap-onboarding',
+          currentType: 'INTJ',
+          axisScores: [],
+          axisStrengths: [],
+          questionCount: 12,
+          createdAt: new Date('2024-04-01T09:16:00.000Z'),
+          source: { type: 'onboarding' as const, sessionId: 'session-onboarding' },
+        },
+      };
+
+      const dailyEntry = {
+        session: {
+          id: 'session-daily',
+          type: 'daily' as const,
+          status: 'completed' as const,
+          localDayKey: '2024-04-02',
+          startedAt: '2024-04-02T08:00:00.000Z',
+          completedAt: '2024-04-02T08:05:00.000Z',
+          createdAt: '2024-04-02T08:00:00.000Z',
+          updatedAt: '2024-04-02T08:05:00.000Z',
+        },
+        snapshot: {
+          id: 'snap-daily',
+          currentType: 'ENTJ',
+          axisScores: [],
+          axisStrengths: [],
+          questionCount: 3,
+          createdAt: new Date('2024-04-02T08:06:00.000Z'),
+          source: { type: 'daily' as const, sessionId: 'session-daily' },
+        },
+      };
+
+      useJournalHistory.mockReturnValue({
+        entries: [dailyEntry, onboardingEntry],
+        isLoading: false,
+        isLoadingMore: false,
+        hasMore: false,
+        error: null,
+        loadMore: jest.fn(),
+      });
+
+      useCurrentDayCompletedSession.mockReturnValue({
+        entry: null,
+        isCurrentDay: false,
+        isLoading: false,
+        error: null,
+      });
+
+      const { getByText } = render(
+        <HeroUINativeProvider>
+          <JournalScreen />
+        </HeroUINativeProvider>
+      );
+
+      await waitFor(() => {
+        expect(getByText('Baseline')).toBeTruthy();
+        expect(getByText('Past Daily Check-ins')).toBeTruthy();
+        expect(getByText('Onboarding')).toBeTruthy();
+        expect(getByText('Daily Check-in')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('Today Completed State', () => {
+    it('should show today card when daily check-in is completed', async () => {
+      const todayEntry = {
+        session: {
+          id: 'session-today',
+          type: 'daily' as const,
+          status: 'completed' as const,
+          localDayKey: '2024-04-03',
+          startedAt: '2024-04-03T08:00:00.000Z',
+          completedAt: '2024-04-03T08:05:00.000Z',
+          createdAt: '2024-04-03T08:00:00.000Z',
+          updatedAt: '2024-04-03T08:05:00.000Z',
+        },
+        snapshot: {
+          id: 'snap-today',
+          currentType: 'ENTP',
+          axisScores: [],
+          axisStrengths: [],
+          questionCount: 3,
+          createdAt: new Date('2024-04-03T08:06:00.000Z'),
+          source: { type: 'daily' as const, sessionId: 'session-today' },
+        },
+      };
+
+      useJournalHistory.mockReturnValue({
+        entries: [todayEntry],
+        isLoading: false,
+        isLoadingMore: false,
+        hasMore: false,
+        error: null,
+        loadMore: jest.fn(),
+      });
+
+      useCurrentDayCompletedSession.mockReturnValue({
+        entry: todayEntry,
+        isCurrentDay: true,
+        isLoading: false,
+        error: null,
+      });
+
+      const { getByText } = render(
+        <HeroUINativeProvider>
+          <JournalScreen />
+        </HeroUINativeProvider>
+      );
+
+      await waitFor(() => {
+        expect(getByText('Today')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('Navigates to Entry Detail', () => {
+    it('should navigate to journal detail when entry is pressed', async () => {
+      const dailyEntry = {
+        session: {
+          id: 'session-daily',
+          type: 'daily' as const,
+          status: 'completed' as const,
+          localDayKey: '2024-04-02',
+          startedAt: '2024-04-02T08:00:00.000Z',
+          completedAt: '2024-04-02T08:05:00.000Z',
+          createdAt: '2024-04-02T08:00:00.000Z',
+          updatedAt: '2024-04-02T08:05:00.000Z',
+        },
+        snapshot: {
+          id: 'snap-daily',
+          currentType: 'ENTJ',
+          axisScores: [],
+          axisStrengths: [],
+          questionCount: 3,
+          createdAt: new Date('2024-04-02T08:06:00.000Z'),
+          source: { type: 'daily' as const, sessionId: 'session-daily' },
+        },
+      };
+
+      useJournalHistory.mockReturnValue({
+        entries: [dailyEntry],
+        isLoading: false,
+        isLoadingMore: false,
+        hasMore: false,
+        error: null,
+        loadMore: jest.fn(),
+      });
+
+      useCurrentDayCompletedSession.mockReturnValue({
+        entry: null,
+        isCurrentDay: false,
+        isLoading: false,
+        error: null,
+      });
+
+      const { getByText } = render(
+        <HeroUINativeProvider>
+          <JournalScreen />
+        </HeroUINativeProvider>
+      );
+
+      await waitFor(() => {
+        expect(getByText('Tue, Apr 2')).toBeTruthy();
+      });
+
+      fireEvent.press(getByText('Tue, Apr 2'));
+      expect(router.push).toHaveBeenCalledWith('/journal/session-daily');
+    });
+  });
+});

--- a/app/(tabs)/journal.tsx
+++ b/app/(tabs)/journal.tsx
@@ -38,9 +38,14 @@ export default function JournalScreen() {
     error: currentDayError,
   } = useCurrentDayCompletedSession();
 
-  const filteredEntries = entries.filter((entry) => {
-    if (!isDayComplete || !currentDayEntry) return entry.session.type === 'daily';
-    return entry.session.id !== currentDayEntry.session.id && entry.session.type === 'daily';
+  const dailyEntries = entries.filter((entry) => entry.session.type === 'daily');
+  const onboardingEntries = entries.filter((entry) => entry.session.type === 'onboarding');
+
+  const hasDailyHistory = dailyEntries.length > 0;
+
+  const filteredPastDailyEntries = dailyEntries.filter((entry) => {
+    if (!isDayComplete || !currentDayEntry) return true;
+    return entry.session.id !== currentDayEntry.session.id;
   });
 
   const handleEntryPress = (sessionId: string) => {
@@ -90,9 +95,9 @@ export default function JournalScreen() {
     );
   }
 
-  const hasEntries = entries.length > 0;
+  const isFullyEmpty = entries.length === 0;
 
-  if (!hasEntries) {
+  if (isFullyEmpty) {
     return (
       <ScrollView
         className="flex-1 bg-background"
@@ -104,9 +109,13 @@ export default function JournalScreen() {
                 <Ionicons name="journal-outline" size={28} color="currentColor" />
               </View>
               <View className="items-center gap-2">
-                <Card.Title className="text-center">Your Journal is Empty</Card.Title>
+                <Card.Title className="text-center">
+                  {isFullyEmpty ? 'Your Journal is Empty' : 'Start Your Daily Entries'}
+                </Card.Title>
                 <Card.Description className="text-center">
-                  Complete daily check-ins to build your history.
+                  {isFullyEmpty
+                    ? 'Complete daily check-ins to build your history.'
+                    : 'Your baseline is saved. Start your first daily check-in to begin your journal.'}
                 </Card.Description>
               </View>
             </View>
@@ -179,7 +188,7 @@ export default function JournalScreen() {
             </Card.Body>
           </Card>
 
-          {filteredEntries.length === 0 && (
+          {filteredPastDailyEntries.length === 0 && (
             <View className="items-center gap-2 py-4">
               <Card.Description className="text-center">
                 No previous daily check-ins yet
@@ -189,15 +198,15 @@ export default function JournalScreen() {
         </View>
       )}
 
-      {filteredEntries.length > 0 && (
+      {onboardingEntries.length > 0 && (
         <View className="gap-3">
           <View className="flex-row items-center gap-2">
             <View className="h-px flex-1 bg-surface-tertiary" />
-            <Text className="text-sm text-foreground-secondary">Past Daily Check-ins</Text>
+            <Text className="text-sm text-foreground-secondary">Baseline</Text>
             <View className="h-px flex-1 bg-surface-tertiary" />
           </View>
           <ListGroup>
-            {filteredEntries.map((entry) => {
+            {onboardingEntries.map((entry) => {
               const session = entry.session;
               const snapshot = entry.snapshot;
               const completedAt = session.completedAt;
@@ -210,11 +219,11 @@ export default function JournalScreen() {
                   <ListGroup.ItemPrefix>
                     <Avatar
                       alt={getEntryTypeLabel(session.type)}
-                      color={session.type === 'onboarding' ? 'accent' : 'success'}
+                      color="accent"
                       size="md"
                       variant="soft">
                       <Avatar.Fallback>
-                        {snapshot?.currentType ?? (session.type === 'onboarding' ? 'ON' : 'DY')}
+                        {snapshot?.currentType ?? 'ON'}
                       </Avatar.Fallback>
                     </Avatar>
                   </ListGroup.ItemPrefix>
@@ -226,7 +235,63 @@ export default function JournalScreen() {
                       <Chip
                         size="sm"
                         variant="soft"
-                        color={session.type === 'onboarding' ? 'accent' : 'success'}>
+                        color="accent">
+                        <Chip.Label>{getEntryTypeLabel(session.type)}</Chip.Label>
+                      </Chip>
+                    </View>
+                    <ListGroup.ItemDescription>
+                      {completedAt ? formatTime(completedAt) : ''}
+                      {snapshot && ` · ${snapshot.currentType}`}
+                    </ListGroup.ItemDescription>
+                  </ListGroup.ItemContent>
+                  <ListGroup.ItemSuffix>
+                    <Ionicons name="chevron-forward" size={18} color="currentColor" />
+                  </ListGroup.ItemSuffix>
+                </ListGroup.Item>
+              );
+            })}
+          </ListGroup>
+        </View>
+      )}
+
+      {filteredPastDailyEntries.length > 0 && (
+        <View className="gap-3">
+          <View className="flex-row items-center gap-2">
+            <View className="h-px flex-1 bg-surface-tertiary" />
+            <Text className="text-sm text-foreground-secondary">Past Daily Check-ins</Text>
+            <View className="h-px flex-1 bg-surface-tertiary" />
+          </View>
+          <ListGroup>
+            {filteredPastDailyEntries.map((entry) => {
+              const session = entry.session;
+              const snapshot = entry.snapshot;
+              const completedAt = session.completedAt;
+
+              return (
+                <ListGroup.Item
+                  key={session.id}
+                  onPress={() => handleEntryPress(session.id)}
+                  className="active:opacity-70">
+                  <ListGroup.ItemPrefix>
+                    <Avatar
+                      alt={getEntryTypeLabel(session.type)}
+                      color="success"
+                      size="md"
+                      variant="soft">
+                      <Avatar.Fallback>
+                        {snapshot?.currentType ?? 'DY'}
+                      </Avatar.Fallback>
+                    </Avatar>
+                  </ListGroup.ItemPrefix>
+                  <ListGroup.ItemContent>
+                    <View className="flex-row items-center gap-2">
+                      <ListGroup.ItemTitle>
+                        {completedAt ? formatDate(completedAt) : 'Unknown date'}
+                      </ListGroup.ItemTitle>
+                      <Chip
+                        size="sm"
+                        variant="soft"
+                        color="success">
                         <Chip.Label>{getEntryTypeLabel(session.type)}</Chip.Label>
                       </Chip>
                     </View>

--- a/app/(tabs)/journal.tsx
+++ b/app/(tabs)/journal.tsx
@@ -90,7 +90,9 @@ export default function JournalScreen() {
     );
   }
 
-  if (entries.length === 0) {
+  const hasEntries = entries.length > 0;
+
+  if (!hasEntries) {
     return (
       <ScrollView
         className="flex-1 bg-background"
@@ -104,7 +106,7 @@ export default function JournalScreen() {
               <View className="items-center gap-2">
                 <Card.Title className="text-center">Your Journal is Empty</Card.Title>
                 <Card.Description className="text-center">
-                  Complete your first daily check-in to see it here.
+                  Complete onboarding or a daily check-in to see it here.
                 </Card.Description>
               </View>
             </View>

--- a/app/(tabs)/journal.tsx
+++ b/app/(tabs)/journal.tsx
@@ -39,8 +39,8 @@ export default function JournalScreen() {
   } = useCurrentDayCompletedSession();
 
   const filteredEntries = entries.filter((entry) => {
-    if (!isDayComplete || !currentDayEntry) return true;
-    return entry.session.id !== currentDayEntry.session.id;
+    if (!isDayComplete || !currentDayEntry) return entry.session.type === 'daily';
+    return entry.session.id !== currentDayEntry.session.id && entry.session.type === 'daily';
   });
 
   const handleEntryPress = (sessionId: string) => {
@@ -106,7 +106,7 @@ export default function JournalScreen() {
               <View className="items-center gap-2">
                 <Card.Title className="text-center">Your Journal is Empty</Card.Title>
                 <Card.Description className="text-center">
-                  Complete onboarding or a daily check-in to see it here.
+                  Complete daily check-ins to build your history.
                 </Card.Description>
               </View>
             </View>
@@ -160,8 +160,7 @@ export default function JournalScreen() {
                     color="accent"
                     alt="Today">
                     <Avatar.Fallback>
-                      {currentDayEntry.snapshot?.currentType ??
-                        (currentDayEntry.session.type === 'onboarding' ? 'ON' : 'DY')}
+                      {currentDayEntry.snapshot?.currentType ?? 'DY'}
                     </Avatar.Fallback>
                   </Avatar>
                   <View className="flex-1">
@@ -179,6 +178,14 @@ export default function JournalScreen() {
               </Button>
             </Card.Body>
           </Card>
+
+          {filteredEntries.length === 0 && (
+            <View className="items-center gap-2 py-4">
+              <Card.Description className="text-center">
+                No previous daily check-ins yet
+              </Card.Description>
+            </View>
+          )}
         </View>
       )}
 
@@ -186,7 +193,7 @@ export default function JournalScreen() {
         <View className="gap-3">
           <View className="flex-row items-center gap-2">
             <View className="h-px flex-1 bg-surface-tertiary" />
-            <Text className="text-sm text-foreground-secondary">Past Check-ins</Text>
+            <Text className="text-sm text-foreground-secondary">Past Daily Check-ins</Text>
             <View className="h-px flex-1 bg-surface-tertiary" />
           </View>
           <ListGroup>

--- a/app/journal/[id].tsx
+++ b/app/journal/[id].tsx
@@ -66,7 +66,27 @@ export default function JournalEntryDetailScreen() {
     );
   }
 
-  if (error || !detail) {
+  if (error) {
+    return (
+      <>
+        <Stack.Screen options={{ title: 'Error' }} />
+        <ScrollView
+          className="flex-1 bg-background"
+          contentContainerStyle={{ gap: 16, padding: 16, paddingTop: 24, paddingBottom: 24 }}>
+          <Card>
+            <Card.Body className="gap-2">
+              <Card.Title className="text-danger">Unable to Load Entry</Card.Title>
+              <Card.Description>
+                {error.message ?? 'An unexpected error occurred while loading this entry.'}
+              </Card.Description>
+            </Card.Body>
+          </Card>
+        </ScrollView>
+      </>
+    );
+  }
+
+  if (!detail) {
     return (
       <>
         <Stack.Screen options={{ title: 'Not Found' }} />
@@ -77,7 +97,7 @@ export default function JournalEntryDetailScreen() {
             <Card.Body className="gap-2">
               <Card.Title className="text-danger">Entry Not Found</Card.Title>
               <Card.Description>
-                {error?.message ?? 'This entry may have been deleted or does not exist.'}
+                This entry may have been deleted or does not exist.
               </Card.Description>
             </Card.Body>
           </Card>

--- a/app/journal/[id].tsx
+++ b/app/journal/[id].tsx
@@ -25,7 +25,7 @@ function formatTime(dateString: string): string {
 }
 
 function getEntryTypeLabel(type: string): string {
-  return type === 'onboarding' ? 'Onboarding' : 'Daily Check-in';
+  return type === 'onboarding' ? 'Baseline (Onboarding)' : 'Daily Check-in';
 }
 
 function getAnswerIcon(answer: PersistedSessionAnswer['answer']): { name: string; color: string } {
@@ -41,7 +41,7 @@ export default function JournalEntryDetailScreen() {
   if (isLoading) {
     return (
       <>
-        <Stack.Screen options={{ title: 'Entry Detail' }} />
+        <Stack.Screen options={{ title: 'Loading...' }} />
         <ScrollView
           className="flex-1 bg-background"
           contentContainerStyle={{ gap: 16, padding: 16, paddingTop: 24, paddingBottom: 24 }}>
@@ -69,15 +69,15 @@ export default function JournalEntryDetailScreen() {
   if (error || !detail) {
     return (
       <>
-        <Stack.Screen options={{ title: 'Entry Detail' }} />
+        <Stack.Screen options={{ title: 'Not Found' }} />
         <ScrollView
           className="flex-1 bg-background"
           contentContainerStyle={{ gap: 16, padding: 16, paddingTop: 24, paddingBottom: 24 }}>
           <Card>
             <Card.Body className="gap-2">
-              <Card.Title className="text-danger">Error loading entry</Card.Title>
+              <Card.Title className="text-danger">Entry Not Found</Card.Title>
               <Card.Description>
-                {error?.message ?? 'Entry not found. It may have been deleted.'}
+                {error?.message ?? 'This entry may have been deleted or does not exist.'}
               </Card.Description>
             </Card.Body>
           </Card>
@@ -93,7 +93,7 @@ export default function JournalEntryDetailScreen() {
     <>
       <Stack.Screen
         options={{
-          title: completedAt ? formatDate(completedAt) : 'Entry Detail',
+          title: completedAt ? formatDate(completedAt) : 'In Progress',
         }}
       />
 <ScrollView

--- a/app/journal/[id].tsx
+++ b/app/journal/[id].tsx
@@ -113,9 +113,14 @@ export default function JournalEntryDetailScreen() {
                 </Avatar.Fallback>
               </Avatar>
               <View className="flex-1 gap-1">
-                <Card.Title>
-                  {getEntryTypeLabel(session.type)}
-                </Card.Title>
+                <View className="flex-row items-center gap-2">
+                  <Card.Title>
+                    {getEntryTypeLabel(session.type)}
+                  </Card.Title>
+                  <Chip size="sm" variant="secondary">
+                    <Chip.Label>Read-Only</Chip.Label>
+                  </Chip>
+                </View>
                 {completedAt && (
                   <Card.Description>
                     Completed at {formatTime(completedAt)}


### PR DESCRIPTION
## Summary
- Treat onboarding as a baseline entry in the Journal view.
- Updated empty‑state messaging to mention onboarding.
- Added a distinct label "Baseline (Onboarding)" for onboarding entries.
- Adjusted entry detail screen titles and error handling.

## Why
Epic 06 expects a read‑only history of completed days, including the onboarding assessment as the first historical entry. This change makes onboarding visible, clearly labeled, and fully integrated with the existing journal UI without altering daily‑check‑in behavior.

## Testing
All existing tests pass (`pnpm test:ci`). Manual verification shows onboarding appears alongside daily entries, with proper labeling and navigation.