### PR TITLE
Update opencode model to minimax-m2.7

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
-          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: cerebras/zai-glm-4.7
+          model: opencode-go/minimax-m2.7


### PR DESCRIPTION
## Summary

- Updated the opencode model from `cerebras/zai-glm-4.7` to `opencode-go/minimax-m2.7`
- Changed the API key secret from `CEREBRAS_API_KEY` to `OPENCODE_API_KEY`