### PR TITLE
Fix lint warning: remove unused hasDailyHistory variable

### DIFF
--- a/app/(tabs)/journal.tsx
+++ b/app/(tabs)/journal.tsx
@@ -41,8 +41,6 @@ export default function JournalScreen() {
   const dailyEntries = entries.filter((entry) => entry.session.type === 'daily');
   const onboardingEntries = entries.filter((entry) => entry.session.type === 'onboarding');
 
-  const hasDailyHistory = dailyEntries.length > 0;
-
   const filteredPastDailyEntries = dailyEntries.filter((entry) => {
     if (!isDayComplete || !currentDayEntry) return true;
     return entry.session.id !== currentDayEntry.session.id;


### PR DESCRIPTION
## Summary
- Removed unused `hasDailyHistory` variable from `app/(tabs)/journal.tsx`
- Fixes ESLint warning about assigned but never used variable
- No behavior changes - pure cleanup

## Verification
- ✅ `pnpm lint` now passes with no warnings
- ✅ Typecheck passes
- ✅ Epic 7 tests continue to pass