### PR TITLE
Refine AGENTS context hierarchy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,303 +1,47 @@
 # AGENTS Guide
 
-## Purpose
+## Scope
+This file applies to the repository root and all files unless a deeper `AGENTS.md` overrides it.
 
-This file is for coding agents working in `/home/hugo/Projects/swipe-check`.
-It summarizes the repository's build, lint, test, and style expectations based on the current codebase.
-
-## Mandatory Epic-to-Issues Routing
-
-If the user asks to convert an epic, product spec, PRD, roadmap, or domain brief into GitHub issues, subissues, or a dependency graph, you must invoke `epic-orchestrator` first.
-
-This includes requests phrased like:
-- "make issues for this epic"
-- "break this down into issues"
-- "turn this spec into GitHub issues"
-- "create an issue hierarchy"
-- "split this epic into subissues"
-- "plan the work from this brief"
-
-Do not create the issues manually with generic GitHub commands until `epic-orchestrator` has run.
-
-If the request is ambiguous but mentions an epic/spec/issues/dependencies, default to `epic-orchestrator`.
-
-## Project Summary
-
-- Framework: Expo + React Native + Expo Router
+## Project at a glance
+- Stack: Expo + React Native + Expo Router
 - Language: TypeScript with `strict: true`
 - Package manager: `pnpm`
-- Styling: `className` via Uniwind, theme tokens via `global.css`, plus React Native `StyleSheet` and inline styles
-- UI library: `heroui-native`
+- Styling: Uniwind `className`, `global.css` theme tokens, plus `StyleSheet` and inline styles
+- UI: custom components/primitives; docs include a historical HeroUI migration plan, but verify `package.json` before assuming any external UI library is installed
 - Testing: Jest with `jest-expo`
 - Linting: `expo lint` via Expo ESLint flat config
 - Module alias: `@/*` maps to the repo root
 
-## Workspace Facts
-
-- Root package: `package.json` at repository root
-- No monorepo packages are currently defined in `pnpm-workspace.yaml`; it only sets `nodeLinker: hoisted`
-- There is no root `src/` directory; app code lives mainly under `app/`, `components/`, `hooks/`, and `constants/`
-- Routing is file-based through Expo Router
-
-## Editor / Agent Rule Files
-
-- No `.cursorrules` file exists
-- No files exist under `.cursor/rules/`
-- No `.github/copilot-instructions.md` file exists
-- No root-level preexisting `AGENTS.md` existed when this guide was generated
-
-If any of those files are added later, update this document to incorporate them.
-
-## Install
-
-Use `pnpm` for dependency installation:
-
-```bash
-pnpm install
-```
-
-Avoid mixing package managers unless the user explicitly asks for it.
-
-## Common Commands
-
-Run commands from the repository root.
-
-### Development
-
-```bash
-pnpm start
-pnpm android
-pnpm ios
-pnpm web
-```
-
-Equivalent direct Expo command:
-
-```bash
-pnpm expo start
-```
-
-### Lint
-
-```bash
-pnpm lint
-```
-
-This runs `expo lint`.
-
-### Typecheck
-
-```bash
-pnpm typecheck
-```
-
-This runs:
-
-```bash
-tsc --noEmit
-```
-
-### Tests
-
-Interactive watch mode:
-
-```bash
-pnpm test
-```
-
-CI/non-watch mode:
-
-```bash
-pnpm test:ci
-```
-
-`test:ci` is the safer default for agents because it exits.
-
-## Running A Single Test
-
-There are currently no committed `*.test.*` or `*.spec.*` files in the repository, but Jest is configured and ready.
-
-Preferred patterns for one file:
-
-```bash
-pnpm test:ci -- path/to/file.test.tsx
-pnpm exec jest --runInBand path/to/file.test.tsx
-```
-
-Run a single test by name:
-
-```bash
-pnpm test:ci -- -t "renders loading state"
-pnpm exec jest --runInBand -t "renders loading state"
-```
-
-Run a single file and a single named test together:
-
-```bash
-pnpm exec jest --runInBand path/to/file.test.tsx -t "renders loading state"
-```
-
-Useful Jest flags in this repo:
-
-```bash
-pnpm exec jest --runInBand --watch false
-pnpm exec jest --runInBand --coverage
-pnpm exec jest --clearCache
-```
-
-## Build Notes
-
-- There is no dedicated `build` script in `package.json`
-- Web/dev bundles are typically exercised through `pnpm web` or `pnpm start`
-- For validation, prefer `pnpm lint`, `pnpm typecheck`, and `pnpm test:ci`
-- Do not invent a production build command unless the user asks for one
-
-## Validation Expectations For Agents
-
-After non-trivial code changes, prefer this sequence when relevant:
-
-```bash
-pnpm lint
-pnpm typecheck
-pnpm test:ci
-```
-
-If the change is narrow and tests do not exist yet, at minimum run the checks that are meaningful for the touched code.
-
-## Code Organization
-
+## Repository layout
 - `app/`: route files, layouts, and screens
-- `components/`: reusable UI and view helpers
-- `components/ui/`: UI primitives/helpers with platform-specific variants where needed
+- `components/`: shared UI and feature view helpers
 - `hooks/`: custom hooks
-- `constants/`: theme and static configuration
-- `scripts/`: utility scripts; not part of the runtime app bundle
+- `constants/`: shared tokens, contracts, and static configuration
+- `lib/local-data/`: SQLite and persistence helpers
+- `scripts/`: utility scripts, if present
 
-## Imports
+There is no root `src/` directory; app code lives mainly under `app/`, `components/`, `hooks/`, and `constants/`.
 
-Follow the existing import style seen across the repo.
+## Working rules
+- Read any deeper `AGENTS.md` files before editing within those directories.
+- Use `@/` imports for internal modules when practical.
+- Keep external imports first, then internal imports, with a blank line between groups.
+- Use semicolons and single quotes in TS/JS files.
+- Keep changes small and preserve local formatting.
+- Prefer explicit types, function components, and typed hooks.
+- Avoid `any`; use `unknown` and narrow it if needed.
+- Handle expected failures at the boundary where they occur.
 
-- Put external imports first
-- Put internal alias imports after external imports
-- Leave a blank line between external and internal import groups
-- Use `@/` aliases for internal modules instead of long relative traversals when possible
-- Prefer `import type` or inline `type` imports for type-only usage when already supported by the import statement
-- Keep side-effect imports near the top and only where required, such as `import 'react-native-reanimated';` and `import '@/global.css';`
+## Validation
+After meaningful changes, run the checks that apply:
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test:ci`
 
-Examples from the codebase:
+Prefer `pnpm test:ci` over `pnpm test` for non-interactive runs.
 
-- `import { StyleSheet, Text, type TextProps } from 'react-native';`
-- `import type { PropsWithChildren, ReactElement } from 'react';`
-- `import { useThemeColor } from '@/hooks/use-theme-color';`
-
-## Formatting
-
-- Match the existing formatting already used in each file
-- Use semicolons
-- Use single quotes in TS/JS files
-- Prefer trailing commas only where the formatter or surrounding code already uses them
-- Keep JSX readable; break props across lines when they get long
-- Favor concise object literals, but wrap long inline style objects or prop lists
-- Do not reformat unrelated files just to satisfy personal preference
-
-There is no separate Prettier config in the repository, so preserve local style and let ESLint/Expo defaults guide formatting.
-
-## TypeScript
-
-- `strict` mode is enabled; keep code type-safe
-- Prefer explicit prop types for exported components
-- Use existing React Native prop types such as `TextProps`, `ViewProps`, or `ComponentProps<typeof X>` instead of re-declaring shapes
-- Prefer unions and derived types over `any`
-- Avoid `any`; use `unknown` if a type is truly unknown and narrow it before use
-- Keep types close to usage unless reused broadly
-- Use platform-specific files when that is the established pattern, for example `icon-symbol.tsx` and `icon-symbol.ios.tsx`
-
-## Components And React Patterns
-
-- Most screen and component modules export a single default or named function component
-- Prefer function components over class components
-- Keep components small and direct unless extraction clearly improves reuse or clarity
-- Use local state with `useState` for simple screen interactions
-- Derive booleans and display state inline when simple, for example `const emailInvalid = ...`
-- Do not add memoization hooks by default unless profiling or existing patterns justify it
-- Follow Expo Router conventions for route names and layouts
-
-## Naming Conventions
-
-- Components: PascalCase
-- Hooks: camelCase with `use` prefix
-- Variables/functions: camelCase
-- Constants: camelCase for local constants, `UPPER_SNAKE_CASE` for true module constants like `HEADER_HEIGHT`
-- Route files: Expo Router naming conventions such as `_layout.tsx`, `modal.tsx`, `(tabs)/index.tsx`
-- Type aliases and prop types: PascalCase, commonly suffixed with `Props`
-
-## Styling Conventions
-
-Styling in this repo is mixed intentionally.
-
-- Prefer `className` for straightforward layout, spacing, colors, and token-driven styling
-- Use `StyleSheet.create` for reusable native style blocks or animation-related style objects
-- Use inline styles for one-off values that are clearer in place
-- Use semantic theme tokens like `bg-background`, `bg-surface-secondary`, and `bg-accent-soft`
-- Use `useThemeColor` or `Colors` when code needs explicit theme-aware values
-- Keep styling native-first; avoid web-only assumptions
-
-The Metro config wraps Expo with Reanimated and Uniwind support, and `global.css` imports Tailwind, Uniwind, and HeroUI styles.
-
-## Error Handling
-
-- Handle errors at the boundary where failure is expected
-- Prefer simple guard clauses over deeply nested conditionals
-- In UI code, fail safely and preserve a usable screen where possible
-- In scripts, log actionable error messages; `scripts/reset-project.js` is the current example
-- Do not swallow errors silently unless there is a deliberate user-experience reason
-- For async event handlers, await promises when the flow depends on them
-
-## Testing Guidance
-
-- Use Jest with the `jest-expo` preset
-- Place tests next to the feature or in a nearby logical test location
-- Prefer testing behavior and rendered output over implementation details
-- For React Native UI, use `@testing-library/react-native`
-- Keep tests deterministic; avoid timers and animation assertions unless necessary
-- If adding tests for router screens, mock only the minimum needed
-
-## Linting Guidance
-
-- ESLint uses `eslint-config-expo/flat`
-- `dist/*` is ignored
-- Do not add new lint disables unless necessary and justified by a real limitation
-- If you must suppress a rule, keep the scope as narrow as possible
-
-## Dependency And Platform Notes
-
-- React 19 and React Native 0.83 are in use
-- Expo SDK 55 is installed even if some sample UI text still references older Expo versions
-- `heroui-native`, `uniwind`, and `tailwindcss` are part of the intended stack
-- `react-native-reanimated` and `react-native-gesture-handler` are configured and should remain correctly initialized
-
-## File-Specific Observations
-
-- `app/_layout.tsx` is the top-level provider composition point
-- `app/(tabs)/_layout.tsx` configures tab navigation
-- `global.css` defines semantic theme variables exposed to class-based styling
-- `constants/theme.ts` is the source of theme colors and fonts for imperative styling
-- `hooks/use-color-scheme.web.ts` uses hydration-aware logic for web
-
-## Agent Do / Don't
-
-- Do make the smallest correct change
-- Do preserve Expo Router file conventions
-- Do use `@/` imports for internal modules where appropriate
-- Do run `pnpm lint` and `pnpm typecheck` after meaningful changes
-- Do use `pnpm test:ci` instead of `pnpm test` for non-interactive verification
-- Do not replace `pnpm` with npm/yarn without a reason
-- Do not add broad architectural layers unless the user asks for them
-- Do not introduce `any`, dead abstractions, or speculative helpers
-- Do not change unrelated formatting or rename files casually
-
-## Quick Command Reference
-
+## Commands
 ```bash
 pnpm install
 pnpm start
@@ -308,6 +52,7 @@ pnpm lint
 pnpm typecheck
 pnpm test
 pnpm test:ci
-pnpm test:ci -- path/to/file.test.tsx
-pnpm exec jest --runInBand path/to/file.test.tsx -t "test name"
 ```
+
+## Epic/issue routing
+If asked to turn an epic, spec, PRD, roadmap, or domain brief into GitHub issues or a dependency graph, invoke `epic-orchestrator` first.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS Guide — app/
+
+## Scope
+Applies to Expo Router files under `app/`.
+
+## Conventions
+- Keep route files thin and route-focused; move reusable logic into hooks or components.
+- Treat `_layout.tsx` files as navigation/provider composition points.
+- Follow Expo Router naming and folder conventions for static, dynamic, and grouped routes.
+- Keep tab and stack configuration centralized in the relevant layout file.
+- Use `Redirect`, `Stack`, and `Tabs` patterns already established in the app.
+- Prefer screen-local state over broad abstractions when the behavior is isolated.
+- Avoid putting shared business logic directly in route files unless it is truly route-specific.

--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS Guide — components/
+
+## Scope
+Applies to reusable UI and feature presentation components under `components/`.
+
+## Conventions
+- Prefer function components with explicit exported prop types.
+- Keep components small and composable; extract only when it improves reuse or clarity.
+- Use React Native prop types and `ComponentProps<typeof X>` where they fit better than hand-rolled shapes.
+- Keep styling native-first.
+  - Use `className` for straightforward layout and spacing.
+  - Use `StyleSheet.create` or inline styles for reusable native or one-off styles.
+- Organize feature-specific components in feature folders instead of a flat bucket.
+- In `components/ui/`, keep primitives prop-driven and presentation-only.
+- Avoid adding memoization hooks unless there is a clear performance reason.
+- If a component has a platform-specific variant, keep the paired file names aligned.

--- a/constants/AGENTS.md
+++ b/constants/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS Guide — constants/
+
+## Scope
+Applies to shared constants and static configuration under `constants/`.
+
+## Conventions
+- Keep files small, stable, and dependency-free when possible.
+- Reserve this folder for design tokens, contracts, enums, and static app configuration.
+- Prefer named exports and simple re-export surfaces.
+- Use semantic names for tokens and shared values.
+- Do not place component, hook, or persistence logic here.

--- a/hooks/AGENTS.md
+++ b/hooks/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS Guide — hooks/
+
+## Scope
+Applies to custom hooks under `hooks/`.
+
+## Conventions
+- Export one hook per file where practical, with `use...` naming.
+- Encapsulate reusable state and derived data-flow; do not render UI from hooks.
+- Keep hook APIs small and predictable.
+- Prefer returning typed objects for multiple values unless an existing pattern uses tuples.
+- Avoid side effects at module scope; initialize lazily inside the hook or helper.
+- Use platform-specific hook files such as `.web.ts` only when the behavior truly differs by platform.
+- Surface loading and error state clearly when hooks depend on app bootstrap or local data.

--- a/lib/local-data/AGENTS.md
+++ b/lib/local-data/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS Guide — lib/local-data/
+
+## Scope
+Applies to persistence, SQLite, and local data helpers under `lib/local-data/`.
+
+## Conventions
+- Treat this as the data/persistence layer; keep UI and route logic out of it.
+- Prefer small, adapter-based modules with one responsibility.
+- Make database lifecycle behavior explicit, especially bootstrap and reset flows.
+- Keep SQL and schema details localized here instead of leaking them into hooks or screens.
+- Return typed results where practical and keep async boundaries clear.
+- If schema behavior changes, document the policy close to the implementation.


### PR DESCRIPTION
## Summary
- Split the AGENTS guidance into scoped files for `app/`, `components/`, `hooks/`, `constants/`, and `lib/local-data/`
- Keep the root AGENTS file focused on repo-wide standards like stack, formatting, validation, and issue-routing guidance
- Remove stale directory-layout assumptions and the outdated HeroUI note from the root guidance
- Add folder-specific conventions that match how this Expo Router app is actually organized

## Why
- Reduces agent context bloat when working in a specific part of the repo
- Makes instructions easier to find and less likely to conflict with local conventions
- Keeps the guidance aligned with the current codebase structure as it evolves

## Notes
- Docs-only change; no runtime behavior was modified
- This branch was recreated from the latest `main` so the review reflects the current AGENTS hierarchy
