### PR TITLE
Fix issue 150: refresh navigation shell

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -24,17 +24,23 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
-        name="journal"
-        options={{
-          title: 'Journal',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="book.fill" color={color} />,
-        }}
-      />
-      <Tabs.Screen
         name="insights"
         options={{
           title: 'Insights',
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="chart.bar.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="more"
+        options={{
+          title: 'More',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="ellipsis.circle.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="journal"
+        options={{
+          href: null,
         }}
       />
     </Tabs>

--- a/app/(tabs)/more.tsx
+++ b/app/(tabs)/more.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Ionicons } from '@expo/vector-icons';
-import { Link } from 'expo-router';
-import { ScrollView, Text } from 'react-native';
 import Constants from 'expo-constants';
+import { router } from 'expo-router';
+import { ScrollView, Text } from 'react-native';
 
-import { Card, CardBody, CardHeader } from '@/components/ui/card';
 import { Button, ButtonIcon, ButtonLabel } from '@/components/ui/button';
+import { Card, CardBody, CardHeader } from '@/components/ui/card';
 import { COLORS, FONT_SIZES, FONT_WEIGHTS, SPACING } from '@/constants/design-system';
 
 export default function MoreScreen() {
@@ -51,14 +51,12 @@ export default function MoreScreen() {
           </Text>
         </CardHeader>
         <CardBody gap="sm">
-          <Link href="/journal" asChild>
-            <Button variant="secondary" style={{ alignSelf: 'stretch' }}>
-              <ButtonIcon>
-                <Ionicons name="book" size={20} color={COLORS.terracotta} />
-              </ButtonIcon>
-              <ButtonLabel>Journal</ButtonLabel>
-            </Button>
-          </Link>
+          <Button variant="secondary" onPress={() => router.push('/journal')} style={{ alignSelf: 'stretch' }}>
+            <ButtonIcon>
+              <Ionicons name="book" size={20} color={COLORS.terracotta} />
+            </ButtonIcon>
+            <ButtonLabel variant="secondary">Journal</ButtonLabel>
+          </Button>
           <Text
             style={{
               fontSize: FONT_SIZES.sm,
@@ -68,14 +66,12 @@ export default function MoreScreen() {
             View your history and past entries
           </Text>
 
-          <Link href="/settings" asChild>
-            <Button variant="secondary" style={{ alignSelf: 'stretch' }}>
-              <ButtonIcon>
-                <Ionicons name="settings" size={20} color={COLORS.terracotta} />
-              </ButtonIcon>
-              <ButtonLabel>Settings</ButtonLabel>
-            </Button>
-          </Link>
+          <Button variant="secondary" onPress={() => router.push('/settings')} style={{ alignSelf: 'stretch' }}>
+            <ButtonIcon>
+              <Ionicons name="settings" size={20} color={COLORS.terracotta} />
+            </ButtonIcon>
+            <ButtonLabel variant="secondary">Settings</ButtonLabel>
+          </Button>
           <Text
             style={{
               fontSize: FONT_SIZES.sm,

--- a/app/(tabs)/more.tsx
+++ b/app/(tabs)/more.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { Ionicons } from '@expo/vector-icons';
+import { Link } from 'expo-router';
+import { ScrollView, Text } from 'react-native';
+import Constants from 'expo-constants';
+
+import { Card, CardBody, CardHeader } from '@/components/ui/card';
+import { Button, ButtonIcon, ButtonLabel } from '@/components/ui/button';
+import { COLORS, FONT_SIZES, FONT_WEIGHTS, SPACING } from '@/constants/design-system';
+
+export default function MoreScreen() {
+  return (
+    <ScrollView
+      style={{ flex: 1, backgroundColor: COLORS.cream }}
+      contentContainerStyle={{
+        gap: SPACING.lg,
+        padding: SPACING.xl,
+        paddingTop: SPACING['3xl'],
+        paddingBottom: SPACING['2xl'],
+      }}>
+      <Card>
+        <CardBody gap="sm">
+          <Text
+            style={{
+              fontSize: FONT_SIZES['2xl'],
+              fontWeight: FONT_WEIGHTS.bold,
+              color: COLORS.softBrown,
+            }}>
+            More
+          </Text>
+          <Text
+            style={{
+              fontSize: FONT_SIZES.base,
+              color: COLORS.warmGray,
+              lineHeight: FONT_SIZES.base * 1.5,
+            }}>
+            App information and additional features
+          </Text>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <Text
+            style={{
+              fontSize: FONT_SIZES.xl,
+              fontWeight: FONT_WEIGHTS.semibold,
+              color: COLORS.softBrown,
+            }}>
+            Secondary Screens
+          </Text>
+        </CardHeader>
+        <CardBody gap="sm">
+          <Link href="/journal" asChild>
+            <Button variant="secondary" style={{ alignSelf: 'stretch' }}>
+              <ButtonIcon>
+                <Ionicons name="book" size={20} color={COLORS.terracotta} />
+              </ButtonIcon>
+              <ButtonLabel>Journal</ButtonLabel>
+            </Button>
+          </Link>
+          <Text
+            style={{
+              fontSize: FONT_SIZES.sm,
+              color: COLORS.warmGray,
+              lineHeight: FONT_SIZES.sm * 1.5,
+            }}>
+            View your history and past entries
+          </Text>
+
+          <Link href="/settings" asChild>
+            <Button variant="secondary" style={{ alignSelf: 'stretch' }}>
+              <ButtonIcon>
+                <Ionicons name="settings" size={20} color={COLORS.terracotta} />
+              </ButtonIcon>
+              <ButtonLabel>Settings</ButtonLabel>
+            </Button>
+          </Link>
+          <Text
+            style={{
+              fontSize: FONT_SIZES.sm,
+              color: COLORS.warmGray,
+              lineHeight: FONT_SIZES.sm * 1.5,
+            }}>
+            App information and local data controls
+          </Text>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <Text
+            style={{
+              fontSize: FONT_SIZES.xl,
+              fontWeight: FONT_WEIGHTS.semibold,
+              color: COLORS.softBrown,
+            }}>
+            About
+          </Text>
+        </CardHeader>
+        <CardBody gap="sm">
+          <Text
+            style={{
+              fontSize: FONT_SIZES.base,
+              color: COLORS.warmGray,
+              lineHeight: FONT_SIZES.base * 1.5,
+            }}>
+            Swipe Check
+          </Text>
+          <Text
+            style={{
+              fontSize: FONT_SIZES.sm,
+              color: COLORS.warmGray,
+            }}>
+            Version {Constants.expoConfig?.version ?? 'Unknown'}
+          </Text>
+        </CardBody>
+      </Card>
+    </ScrollView>
+  );
+}

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -14,7 +14,8 @@ type IconSymbolName =
   | 'book.fill'
   | 'paperplane.fill'
   | 'chevron.left.forwardslash.chevron.right'
-  | 'chevron.right';
+  | 'chevron.right'
+  | 'ellipsis.circle.fill';
 
 type IconMapping = Record<IconSymbolName, ComponentProps<typeof MaterialIcons>['name']>;
 
@@ -34,6 +35,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'ellipsis.circle.fill': 'more-horiz',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
What changed
- Added a new More tab screen with links to Journal and Settings plus app metadata.
- Updated the tabs layout so the primary tab bar now shows Today, Insights, and More only.
- Hid Journal from the tab bar while keeping it routable.
- Added the missing tab icon mapping needed for the More tab.

Why
- This implements issue 150 / Epic 09.1 by de-emphasizing secondary surfaces and keeping the habit flow primary.

How to review
- Open the app and confirm the tab bar shows Today, Insights, and More.
- Confirm More links to Journal and Settings.
- Confirm direct routes to Journal and Settings still work.
- Run the navigation smoke path or rely on the passing lint/typecheck/test suite.

Closes #150